### PR TITLE
Fix `install` command and add changelog

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,21 @@
+name: Testing
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+    contents: read
+
+jobs:
+  test-rust:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Dwarnings"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features
+      - name: Run Tests
+        run: cargo test --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog],
+and this project adheres to [Semantic Versioning].
+
+## [Unreleased]
+
+- /
+
+## [0.1.1] - 2023-11-25
+
+### Fixed
+
+- `install` now creates the attribute and config files if they do not exist, instead of erroring
+- git filter commands registered by `install` are now correct
+
+## [0.1.0] - 2023-11-25
+
+- initial release
+
+<!-- Links -->
+[keep a changelog]: https://keepachangelog.com/en/1.0.0/
+[semantic versioning]: https://semver.org/spec/v2.0.0.html
+
+<!-- Versions -->
+[unreleased]: https://github.com/felixgwilliams/nbwipers/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/felixgwilliams/nbwipers/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/felixgwilliams/nbwipers/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "nbwipers"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nbwipers"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Wipe clean your Jupyter Notebooks!"

--- a/src/install.rs
+++ b/src/install.rs
@@ -41,7 +41,11 @@ pub fn install_config(config_type: GitConfigType) -> Result<(), Error> {
             dotgit.join(source.storage_location(&mut gix_path::env::var).unwrap())
         }
     };
-    let mut file = gix_config::File::from_path_no_includes(file_path.clone(), source)?;
+    let mut file = if file_path.is_file() {
+        gix_config::File::from_path_no_includes(file_path.clone(), source)?
+    } else {
+        gix_config::File::new(gix_config::file::Metadata::from(source))
+    };
 
     // fails for invalid section names. This one is ok
     #[allow(clippy::unwrap_used)]
@@ -116,42 +120,48 @@ pub fn install_attributes(
     attribute_file: Option<&Path>,
 ) -> Result<(), Error> {
     let file_path = resolve_attribute_file(config_type, attribute_file)?;
-    let attribute_bytes = fs::read(&file_path)?;
-
     let to_add_lines = &[
         "*.ipynb filter=nbwipers",
         "*.zpln filter=nbwipers",
         "*.ipynb diff=nbwipers",
     ];
-    // let to_add_str = to_add_lines.join("\n").as_bytes();
-    #[allow(clippy::unwrap_used)]
-    let to_add_values = to_add_lines
-        .iter()
-        .map(|x| gix_attributes::parse(x.as_bytes()).next().unwrap().unwrap())
-        .flat_map(|(kind, rhs, _)| {
-            rhs.filter_map(Result::ok)
-                .map(move |a| (kind.clone(), a.to_owned()))
-        });
+    if file_path.is_file() {
+        let attribute_bytes = fs::read(&file_path)?;
 
-    let mut to_add: BTreeMap<_, _> = to_add_values.zip(to_add_lines).collect();
-    let extra_newline = attribute_bytes.last() == Some(&b'\n');
+        // let to_add_str = to_add_lines.join("\n").as_bytes();
+        #[allow(clippy::unwrap_used)]
+        let to_add_values = to_add_lines
+            .iter()
+            .map(|x| gix_attributes::parse(x.as_bytes()).next().unwrap().unwrap())
+            .flat_map(|(kind, rhs, _)| {
+                rhs.filter_map(Result::ok)
+                    .map(move |a| (kind.clone(), a.to_owned()))
+            });
 
-    let mut lines = gix_attributes::parse(&attribute_bytes);
+        let mut to_add: BTreeMap<_, _> = to_add_values.zip(to_add_lines).collect();
+        let extra_newline = attribute_bytes.last() == Some(&b'\n');
 
-    for (kind, x, _) in lines.by_ref().filter_map(Result::ok) {
-        //
-        for ass in x.filter_map(Result::ok) {
-            to_add.remove(&(kind.clone(), ass.to_owned()));
+        let mut lines = gix_attributes::parse(&attribute_bytes);
+
+        for (kind, x, _) in lines.by_ref().filter_map(Result::ok) {
+            //
+            for ass in x.filter_map(Result::ok) {
+                to_add.remove(&(kind.clone(), ass.to_owned()));
+            }
         }
-    }
-    println!("{to_add:?}");
-    if !to_add.is_empty() {
-        let mut writer = fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&file_path)?;
-        let extra = if extra_newline { "" } else { "\n" };
-        writeln!(writer, "{}{}", extra, to_add.values().join("\n"))?;
+        if !to_add.is_empty() {
+            let mut writer = fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&file_path)?;
+            let extra = if extra_newline { "" } else { "\n" };
+            writeln!(writer, "{}{}", extra, to_add.values().join("\n"))?;
+        }
+    } else {
+        let mut writer = fs::File::create(file_path)?;
+        for line in to_add_lines {
+            writeln!(writer, "{line}")?;
+        }
     }
 
     Ok(())

--- a/src/install.rs
+++ b/src/install.rs
@@ -56,7 +56,7 @@ pub fn install_config(config_type: GitConfigType) -> Result<(), Error> {
     #[allow(clippy::unwrap_used)]
     nbwipers_section.set(
         Key::try_from("clean").unwrap(),
-        BStr::new(format!("\"{}\" clean", cur_exe_str.as_str()).as_str()),
+        BStr::new(format!("\"{}\" clean -", cur_exe_str.as_str()).as_str()),
     );
     #[allow(clippy::unwrap_used)]
     nbwipers_section.set(Key::try_from("smudge").unwrap(), BStr::new("cat"));
@@ -150,6 +150,8 @@ pub fn install_attributes(
             }
         }
         if !to_add.is_empty() {
+            println!("Writing to {}", file_path.display());
+
             let mut writer = fs::OpenOptions::new()
                 .create(true)
                 .append(true)
@@ -158,7 +160,9 @@ pub fn install_attributes(
             writeln!(writer, "{}{}", extra, to_add.values().join("\n"))?;
         }
     } else {
+        println!("Writing to {}", file_path.display());
         let mut writer = fs::File::create(file_path)?;
+
         for line in to_add_lines {
             writeln!(writer, "{line}")?;
         }


### PR DESCRIPTION
Fixes:

- `install` now creates the attribute and config files if they do not exist, instead of erroring
- git filter commands registered by `install` are now correct