### PR TITLE
Smudge for Kernelspec

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --all-features --workspace --timeout 1200 --out xml --engine llvm
+          cargo tarpaulin --verbose --all-features --workspace --timeout 1200 --out xml --engine llvm --rustflags="-C opt-level=0"
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "nbwipers"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bstr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,9 +698,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -781,12 +781,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
+ "rayon",
  "serde",
 ]
 
@@ -966,6 +967,7 @@ dependencies = [
  "gix-path",
  "globset",
  "ignore",
+ "indexmap 2.6.0",
  "inquire",
  "insta",
  "itertools",
@@ -1194,7 +1196,7 @@ version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
@@ -1220,7 +1222,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1433,7 +1435,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ gix-discover = "0.35.0"
 gix-path = "0.10.5"
 globset = "0.4.14"
 ignore = "0.4.22"
+indexmap = { version = "2.6.0", features = ["rayon", "serde"] }
 inquire = "0.7.0"
 itertools = "0.13.0"
 path-absolutize = { version = "3.1.1", features = ["once_cell_cache"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nbwipers"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 description = "Wipe clean your Jupyter Notebooks!"

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -12,6 +12,7 @@ This document contains the help content for the `nbwipers` command-line program.
 * [`nbwipers uninstall`↴](#nbwipers-uninstall)
 * [`nbwipers check-install`↴](#nbwipers-check-install)
 * [`nbwipers show-config`↴](#nbwipers-show-config)
+* [`nbwipers record`↴](#nbwipers-record)
 * [`nbwipers hook`↴](#nbwipers-hook)
 * [`nbwipers hook check-large-files`↴](#nbwipers-hook-check-large-files)
 
@@ -30,6 +31,7 @@ Wipe clean your Jupyter Notebooks!
 * `uninstall` — uninstall nbwipers as a git filter
 * `check-install` — check whether nbwipers is setup as a git filter
 * `show-config` — Show configuration
+* `record` — Record Kernelspec metadata for notebooks
 * `hook` — Commands for pre-commit hooks
 
 ## `nbwipers install`
@@ -78,6 +80,7 @@ clean all notebooks in a given path
 * `--keep-count` — keep cell execution count. Disable with `--drop count`
 * `--drop-id` — replace cell ids with sequential ids. Disable with `--keep-id`
 * `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
+* `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
 * `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
 * `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
 * `--exclude <EXCLUDE>` — List of file patterns to ignore
@@ -108,6 +111,7 @@ check notebooks in a given path for elements that would be removed by `clean`
 * `--keep-count` — keep cell execution count. Disable with `--drop count`
 * `--drop-id` — replace cell ids with sequential ids. Disable with `--keep-id`
 * `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
+* `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
 * `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
 * `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
 * `--exclude <EXCLUDE>` — List of file patterns to ignore
@@ -135,6 +139,7 @@ clean a single notebook
 * `--keep-count` — keep cell execution count. Disable with `--drop count`
 * `--drop-id` — replace cell ids with sequential ids. Disable with `--keep-id`
 * `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
+* `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
 * `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
 * `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
 * `--exclude <EXCLUDE>` — List of file patterns to ignore
@@ -203,6 +208,37 @@ Show configuration
 * `--keep-count` — keep cell execution count. Disable with `--drop count`
 * `--drop-id` — replace cell ids with sequential ids. Disable with `--keep-id`
 * `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
+* `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
+* `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
+* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
+* `--exclude <EXCLUDE>` — List of file patterns to ignore
+* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore
+
+## `nbwipers record`
+
+Record Kernelspec metadata for notebooks
+
+**Usage:** `nbwipers record [OPTIONS] [PATH]`
+
+###### **Arguments:**
+
+* `<PATH>`
+
+###### **Options:**
+
+* `--remove <REMOVE>`
+* `--clear`
+* `--sync`
+* `-c`, `--config <CONFIG>` — path to pyproject.toml/.nbwipers.toml/nbwipers.toml file containing nbwipers settings. If not given use the file in the current working directory or the first such file in its containing folders
+* `--isolated` — Ignore all configuration files
+* `--allow-no-notebooks` — Do not return an error if no notebooks are found
+* `--extra-keys <EXTRA_KEYS>` — extra keys to remove in the notebook or cell metadata, separated by commas. Must start with `metadata` or `cell.metadata`
+* `--drop-empty-cells` — drop empty cells. Disable with `--keep-empty-cells`
+* `--keep-output` — keep cell output. Disable with `--drop-output`
+* `--keep-count` — keep cell execution count. Disable with `--drop count`
+* `--drop-id` — replace cell ids with sequential ids. Disable with `--keep-id`
+* `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
+* `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
 * `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
 * `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
 * `--exclude <EXCLUDE>` — List of file patterns to ignore

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 test:
     cargo test
 test-cov:
-    cargo tarpaulin --verbose --all-features --workspace -o stdout -o html -o lcov --engine llvm
+    cargo tarpaulin --verbose --all-features --workspace -o stdout -o html -o lcov --engine llvm --rustflags="-C opt-level=0"
 cli-docs:
     cargo run -q --features=markdown-help -- --markdown-help check | sed -z -e 's/\n\n *Possible values: `true`, `false`\n//g'  > CommandLineHelp.md
     -markdownlint-cli2 CommandLineHelp.md --fix

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -354,6 +354,9 @@ impl ConfigOverrides {
         if let Some(extend_exclude) = &self.extend_exclude {
             config.extend_exclude.extend(extend_exclude.clone());
         }
+        if let Some(strip_kernel_info) = &self.strip_kernel_info {
+            config.strip_kernel_info = Some(*strip_kernel_info);
+        }
         config
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,9 @@ pub enum Commands {
     ShowConfig(ShowConfigCommand),
     /// Record Kernelspec metadata for notebooks
     Record(RecordCommand),
+    /// Add back kernelspec metadata to the notebook as a smudge
+    #[clap(hide(true))]
+    Smudge(SmudgeCommand),
     /// Commands for pre-commit hooks
     #[command(subcommand)]
     Hook(HookCommands),
@@ -233,6 +236,11 @@ pub struct CheckInstallCommand {
     /// Git config type to check
     #[clap(value_enum)]
     pub config_type: Option<GitConfigType>,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct SmudgeCommand {
+    pub path: String,
 }
 
 #[derive(Clone, Debug, ValueEnum, Copy)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,12 @@ pub struct CommonArgs {
 
     #[arg(long, overrides_with("strip_init_cell"), hide = true)]
     pub keep_init_cell: bool,
+    /// Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
+    #[arg(long, overrides_with("keep_kernel_info"))]
+    pub strip_kernel_info: bool,
+
+    #[arg(long, overrides_with("strip_kernel_info"), hide = true)]
+    pub keep_kernel_info: bool,
 
     /// comma-separated list of tags that will cause the cell to be dropped
     #[arg(long, value_delimiter = ',')]
@@ -255,6 +261,7 @@ pub enum GitConfigType {
 
 #[derive(Clone, Debug, Default)]
 pub struct ConfigOverrides {
+    pub strip_kernel_info: Option<bool>,
     pub extra_keys: Option<Vec<ExtraKey>>,
     pub drop_empty_cells: Option<bool>,
     pub drop_output: Option<bool>,
@@ -301,6 +308,7 @@ impl CommonArgs {
                 keep_keys: self.keep_keys,
                 extend_exclude: self.extend_exclude,
                 exclude: self.exclude,
+                strip_kernel_info: resolve_bool_arg(self.strip_kernel_info, self.keep_kernel_info),
             },
         )
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,8 @@ pub enum Commands {
     CheckInstall(CheckInstallCommand),
     /// Show configuration
     ShowConfig(ShowConfigCommand),
+    /// Record Kernelspec metadata for notebooks
+    Record(RecordCommand),
     /// Commands for pre-commit hooks
     #[command(subcommand)]
     Hook(HookCommands),
@@ -216,6 +218,13 @@ pub struct UninstallCommand {
     pub attribute_file: Option<PathBuf>,
 }
 
+#[derive(Clone, Debug, Parser)]
+pub struct RecordCommand {
+    pub path: Option<PathBuf>,
+
+    #[clap(flatten)]
+    pub common: CommonArgs,
+}
 #[derive(Clone, Debug, Parser)]
 pub struct CheckInstallCommand {
     /// Exit zero regardless of install status

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,14 @@ pub struct UninstallCommand {
 pub struct RecordCommand {
     pub path: Option<PathBuf>,
 
+    #[arg(long)]
+    pub remove: Vec<PathBuf>,
+
+    #[arg(long)]
+    pub clear: bool,
+    #[arg(long)]
+    pub sync: bool,
+
     #[clap(flatten)]
     pub common: CommonArgs,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ pub struct ConfigurationSection {
     pub keep_keys: Option<Vec<ExtraKey>>,
     pub exclude: Option<Vec<String>>,
     pub extend_exclude: Option<Vec<String>>,
+    pub strip_kernel_info: Option<bool>,
 }
 
 impl ConfigurationSection {
@@ -56,6 +57,7 @@ impl ConfigurationSection {
             keep_keys: self.keep_keys,
             exclude,
             extend_exclude,
+            strip_kernel_info: self.strip_kernel_info,
         }
     }
 }
@@ -72,6 +74,7 @@ pub struct Configuration {
     pub keep_keys: Option<Vec<ExtraKey>>,
     pub exclude: Option<Vec<FilePattern>>,
     pub extend_exclude: Vec<FilePattern>,
+    pub strip_kernel_info: Option<bool>,
 }
 
 pub const EXTRA_KEYS: &[&str] = &[
@@ -154,6 +157,11 @@ fn make_globset<I: IntoIterator<Item = FilePattern>>(patterns: I) -> anyhow::Res
 impl Configuration {
     pub fn into_settings(self) -> Result<Settings, anyhow::Error> {
         let mut extra_keys = default_extra_keys();
+        let strip_kernel_info = self.strip_kernel_info.unwrap_or(false);
+        if strip_kernel_info {
+            extra_keys.insert(ExtraKey::from_str("metadata.kernelspec").unwrap());
+            extra_keys.insert(ExtraKey::from_str("metadata.language_info.version").unwrap());
+        }
         extra_keys.extend(self.extra_keys.unwrap_or_default());
         for key in &self.keep_keys.unwrap_or_default() {
             extra_keys.remove(key);
@@ -189,6 +197,7 @@ impl Configuration {
             exclude_,
             extend_exclude,
             extend_exclude_,
+            strip_kernel_info,
         })
     }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -61,10 +61,19 @@ pub enum FoundNotebooks {
     Files(Vec<PathBuf>),
 }
 
-pub fn find_notebooks(paths: &[PathBuf], settings: &Settings) -> Result<FoundNotebooks, Error> {
+pub fn find_notebooks_or_stdin(
+    paths: &[PathBuf],
+    settings: &Settings,
+) -> Result<FoundNotebooks, Error> {
     if paths == [Path::new("-")] {
         return Ok(FoundNotebooks::Stdin);
     }
+    find_notebooks(paths, settings)
+}
+pub fn find_notebooks<P: AsRef<Path>>(
+    paths: &[P],
+    settings: &Settings,
+) -> Result<FoundNotebooks, Error> {
     let paths: Vec<PathBuf> = paths.iter().map(normalize_path).unique().collect();
     let (first_path, rest_paths) = paths
         .split_first()
@@ -133,7 +142,7 @@ pub fn find_notebooks(paths: &[PathBuf], settings: &Settings) -> Result<FoundNot
     }
 }
 
-pub fn read_nb(path: &Path) -> Result<RawNotebook, NBReadError> {
+pub fn read_nb<P: AsRef<Path>>(path: P) -> Result<RawNotebook, NBReadError> {
     let f = File::open(path)?;
     let rdr = BufReader::new(f);
 

--- a/src/install/gitconfig.rs
+++ b/src/install/gitconfig.rs
@@ -43,7 +43,10 @@ pub fn install_config(config_file: Option<&Path>, config_type: GitConfigType) ->
     );
 
     #[allow(clippy::unwrap_used)]
-    nbwipers_section.set(ValueName::try_from("smudge").unwrap(), BStr::new("cat"));
+    nbwipers_section.set(
+        ValueName::try_from("smudge").unwrap(),
+        BStr::new(format!("\"{}\" smudge %f", cur_exe_str.as_str()).as_str()),
+    );
 
     // fails for invalid section names. This one is ok
     #[allow(clippy::unwrap_used)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod extra_keys;
 pub mod files;
 pub mod hooks;
 pub mod install;
+pub mod record;
 pub mod schema;
 pub mod settings;
 pub mod strip;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod install;
 pub mod record;
 pub mod schema;
 pub mod settings;
+pub mod smudge;
 pub mod strip;
 pub mod utils;
 #[allow(clippy::unwrap_used)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,6 @@ use std::{
 use anyhow::{anyhow, bail, Error};
 use clap::Parser;
 use colored::Colorize;
-use nbwipers::cli::{
-    self as cli, resolve_bool_arg, CheckCommand, CheckInstallCommand, CleanAllCommand,
-    CleanCommand, Commands, CommonArgs, InstallCommand, OutputFormat, ShowConfigCommand,
-    UninstallCommand,
-};
 use nbwipers::config::{resolve, Configuration};
 use nbwipers::files::{
     find_notebooks_or_stdin, read_nb, read_nb_stdin, relativize_path, FoundNotebooks,
@@ -34,6 +29,14 @@ use nbwipers::strip::{strip_single, StripResult};
 use nbwipers::{
     check::{self as check, PathCheckResult},
     cli::RecordCommand,
+};
+use nbwipers::{
+    cli::{
+        self as cli, resolve_bool_arg, CheckCommand, CheckInstallCommand, CleanAllCommand,
+        CleanCommand, Commands, CommonArgs, InstallCommand, OutputFormat, ShowConfigCommand,
+        SmudgeCommand, UninstallCommand,
+    },
+    smudge::smudge,
 };
 use rayon::prelude::*;
 use std::io::Write;
@@ -220,6 +223,7 @@ fn main() -> Result<(), Error> {
         ),
         Commands::Hook(ref cmd) => hooks(cmd),
         Commands::Record(RecordCommand { ref path, common }) => record(path.as_ref(), common),
+        Commands::Smudge(SmudgeCommand { path }) => smudge(path),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use std::{
 use anyhow::{anyhow, bail, Error};
 use clap::Parser;
 use colored::Colorize;
+use nbwipers::check::{self as check, PathCheckResult};
 use nbwipers::config::{resolve, Configuration};
 use nbwipers::files::{
     find_notebooks_or_stdin, read_nb, read_nb_stdin, relativize_path, FoundNotebooks,
@@ -26,10 +27,6 @@ use nbwipers::install;
 use nbwipers::record::record;
 use nbwipers::settings::Settings;
 use nbwipers::strip::{strip_single, StripResult};
-use nbwipers::{
-    check::{self as check, PathCheckResult},
-    cli::RecordCommand,
-};
 use nbwipers::{
     cli::{
         self as cli, resolve_bool_arg, CheckCommand, CheckInstallCommand, CleanAllCommand,
@@ -222,7 +219,7 @@ fn main() -> Result<(), Error> {
             resolve_bool_arg(show_all, no_show_defaults).unwrap_or(false),
         ),
         Commands::Hook(ref cmd) => hooks(cmd),
-        Commands::Record(RecordCommand { ref path, common }) => record(path.as_ref(), common),
+        Commands::Record(cmd) => record(cmd),
         Commands::Smudge(SmudgeCommand { path }) => smudge(path),
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 use thiserror::Error as ThisError;
 
 #[derive(ThisError, Debug)]
-enum RecordError {
+pub enum RecordError {
     #[error("No .git dir")]
     NoGitDir,
     #[error("Invalid git repo")]
@@ -36,7 +36,7 @@ enum RecordError {
     SerdeWriteError(serde_json::Error),
 }
 
-fn get_kernelspec_file<P: AsRef<Path>>(path: P) -> Result<PathBuf, RecordError> {
+pub fn get_kernelspec_file<P: AsRef<Path>>(path: P) -> Result<PathBuf, RecordError> {
     let git_dir = path.as_ref().join(gix_discover::DOT_GIT_DIR);
     if !git_dir.is_dir() {
         return Err(RecordError::NoGitDir);
@@ -49,7 +49,7 @@ fn get_kernelspec_file<P: AsRef<Path>>(path: P) -> Result<PathBuf, RecordError> 
     fs::create_dir_all(&nbwipers_dir).map_err(RecordError::FailedCreateNbwipersDir)?;
     Ok(nbwipers_dir.join("kernelspec_store.json"))
 }
-fn read_kernelspec_file<P: AsRef<Path>>(
+pub fn read_kernelspec_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<Option<IndexMap<String, KernelSpecInfo>>, RecordError> {
     if path.as_ref().exists() {

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,0 +1,117 @@
+use std::{
+    fmt::Debug,
+    fs::{self, File},
+    io::{BufReader, BufWriter},
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    cli::CommonArgs,
+    files::{find_notebooks, get_cwd, read_nb, relativize_path, FoundNotebooks},
+    schema::RawNotebook,
+    settings::Settings,
+};
+use anyhow::Error;
+use indexmap::IndexMap;
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error as ThisError;
+
+#[derive(ThisError, Debug)]
+enum RecordError {
+    #[error("No .git dir")]
+    NoGitDir,
+    #[error("Invalid git repo")]
+    InvalidGitRepo(#[from] gix_discover::is_git::Error),
+    #[error("Not a git worktree")]
+    NotAGitWorktree,
+    #[error("Failed to create nbwipers dir")]
+    FailedCreateNbwipersDir(std::io::Error),
+    #[error("Failed to read existing kernelspec file")]
+    FailedReadKernelspecFile(std::io::Error),
+    #[error("Invalid Kernelspec file")]
+    InvalidKernelspecFile(serde_json::Error),
+    #[error("Serde Write Error")]
+    SerdeWriteError(serde_json::Error),
+}
+
+fn get_kernelspec_file<P: AsRef<Path>>(path: P) -> Result<PathBuf, RecordError> {
+    let git_dir = path.as_ref().join(gix_discover::DOT_GIT_DIR);
+    if !git_dir.is_dir() {
+        return Err(RecordError::NoGitDir);
+    }
+    let git_type = gix_discover::is_git(&git_dir)?;
+    if !matches!(git_type, gix_discover::repository::Kind::WorkTree { .. }) {
+        return Err(RecordError::NotAGitWorktree);
+    }
+    let nbwipers_dir = git_dir.join("nbwipers");
+    fs::create_dir_all(&nbwipers_dir).map_err(RecordError::FailedCreateNbwipersDir)?;
+    Ok(nbwipers_dir.join("kernelspec_store.json"))
+}
+fn read_kernelspec_file<P: AsRef<Path>>(
+    path: P,
+) -> Result<Option<IndexMap<String, KernelSpecInfo>>, RecordError> {
+    if path.as_ref().exists() {
+        let file = File::open(path).map_err(RecordError::FailedReadKernelspecFile)?;
+        let buf = BufReader::new(file);
+        Ok(Some(
+            serde_json::from_reader(buf).map_err(RecordError::InvalidKernelspecFile)?,
+        ))
+    } else {
+        Ok(None)
+    }
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KernelSpecInfo {
+    pub kernelspec: Value,
+    pub python_version: Option<String>,
+}
+
+pub fn record(path: Option<&PathBuf>, cli: CommonArgs) -> Result<(), Error> {
+    let path = path.cloned().unwrap_or_else(get_cwd);
+    let (args, overrides) = cli.partition();
+    let settings = Settings::construct(args.config.as_deref(), args.isolated, &overrides)?;
+
+    let kernelspec_file = get_kernelspec_file(&path)?;
+    let mut kernelspec_records = read_kernelspec_file(&kernelspec_file)?.unwrap_or_default();
+
+    let FoundNotebooks::Files(files) = find_notebooks(&[&path], &settings)? else {
+        return Ok(());
+    };
+    let kernelspecs = get_kernelspecs(&files);
+    for (nb, kernel) in kernelspecs {
+        kernelspec_records.insert(nb, kernel);
+    }
+    let out_file = File::create(kernelspec_file)?;
+    let mut buf = BufWriter::new(out_file);
+    Ok(serde_json::to_writer(&mut buf, &kernelspec_records)
+        .map_err(RecordError::SerdeWriteError)?)
+}
+fn extract_kernel_info(nb: &RawNotebook) -> Option<KernelSpecInfo> {
+    let kernelspec = nb.metadata.get("kernelspec");
+    let python_version = nb
+        .metadata
+        .get("language_info")
+        .and_then(|li| li.get("version"));
+    if kernelspec.is_none() && python_version.is_none() {
+        return None;
+    }
+    Some(KernelSpecInfo {
+        kernelspec: kernelspec.cloned().unwrap_or(Value::Null),
+        python_version: python_version.and_then(Value::as_str).map(str::to_string),
+    })
+}
+
+fn get_kernelspecs<P: AsRef<Path> + Sync + Debug>(nbs: &[P]) -> IndexMap<String, KernelSpecInfo> {
+    nbs.par_iter()
+        .map(|nb| (nb, read_nb(nb)))
+        .filter_map(|(path, nb_res)| match nb_res {
+            Ok(nb) => Some((path.as_ref(), nb)),
+            Err(_) => None,
+        })
+        .filter_map(|(path, nb_res)| {
+            extract_kernel_info(&nb_res).map(|k| (relativize_path(path), k))
+        })
+        .collect()
+}

--- a/src/record.rs
+++ b/src/record.rs
@@ -45,7 +45,7 @@ pub fn get_kernelspec_file<P: AsRef<Path>>(path: P) -> Result<PathBuf, RecordErr
     if !matches!(git_type, gix_discover::repository::Kind::WorkTree { .. }) {
         return Err(RecordError::NotAGitWorktree);
     }
-    let nbwipers_dir = git_dir.join("nbwipers");
+    let nbwipers_dir = git_dir.join("x-nbwipers");
     fs::create_dir_all(&nbwipers_dir).map_err(RecordError::FailedCreateNbwipersDir)?;
     Ok(nbwipers_dir.join("kernelspec_store.json"))
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,7 +31,6 @@ impl Settings {
         overrides: &ConfigOverrides,
     ) -> Result<Self, anyhow::Error> {
         let mut config = if isolated {
-            dbg!("isolated!");
             Configuration::default()
         } else {
             let (config_sec, config_path) = resolve(config_file)?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -16,6 +16,7 @@ pub struct Settings {
     pub drop_count: bool,
     pub drop_id: bool,
     pub strip_init_cell: bool,
+    pub strip_kernel_info: bool,
     pub exclude: Vec<String>,
     #[serde(skip_serializing)]
     pub exclude_: GlobSet,

--- a/src/smudge.rs
+++ b/src/smudge.rs
@@ -1,0 +1,78 @@
+use std::io::{stdin, Read};
+use std::io::{stdout, Write};
+
+use anyhow::bail;
+use serde_json::{json, Value};
+
+use crate::files::get_cwd;
+use crate::record::{get_kernelspec_file, read_kernelspec_file, KernelSpecInfo};
+use crate::schema::RawNotebook;
+use crate::strip::write_nb;
+
+pub fn smudge(path: String) -> Result<(), anyhow::Error> {
+    let mut in_nb_bytes = Vec::new();
+    stdin().lock().read_to_end(&mut in_nb_bytes)?;
+    // let lock = std_in.lock();
+    // serde_json::from_reader(lock)?
+    let kernelspec_info =
+        read_kernelspec_file(get_kernelspec_file(get_cwd())?)?.unwrap_or_default();
+    match kernelspec_info.get(&path) {
+        Some(kernel_spec) => {
+            let out_nb = maybe_replace_kernelspec(&in_nb_bytes, kernel_spec)?;
+            write_nb(stdout(), &out_nb)?;
+        }
+        None => {
+            stdout().write_all(&in_nb_bytes)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn maybe_replace_kernelspec(
+    nb_in: &[u8],
+    kernelspec_info: &KernelSpecInfo,
+) -> Result<RawNotebook, anyhow::Error> {
+    let mut nb = serde_json::from_slice::<RawNotebook>(nb_in)?;
+
+    if !kernelspec_info.kernelspec.is_null() {
+        match nb.metadata {
+            Value::Null => {
+                nb.metadata = json!(
+                    {
+                        "kernelspec": kernelspec_info.kernelspec,
+                    }
+                )
+            }
+            Value::Object(ref mut meta) => {
+                if !meta.contains_key("kernelspec") {
+                    meta.insert("kernelspec".to_string(), json!(kernelspec_info.kernelspec));
+                }
+            }
+            _ => bail!("Unexpected metadata type"),
+        }
+    }
+    if let Some(ref version) = kernelspec_info.python_version {
+        match nb.metadata {
+            Value::Null => {
+                nb.metadata = json!(
+                    {"language_info":{"version":version}}
+                )
+            }
+            Value::Object(ref mut meta) => match meta.get_mut("language_info") {
+                Some(Value::Null) => {
+                    meta.insert("language_info".to_string(), json!({"version":version}));
+                }
+                Some(Value::Object(lang_info)) => {
+                    if !lang_info.contains_key("version") {
+                        lang_info.insert("version".to_string(), json!(version));
+                    }
+                }
+                _ => bail!("Unexpected language info type"),
+            },
+            _ => bail!("Unexpected metadata type"),
+        }
+    };
+
+    Ok(nb)
+}

--- a/src/smudge.rs
+++ b/src/smudge.rs
@@ -46,7 +46,11 @@ fn maybe_replace_kernelspec(
             }
             Value::Object(ref mut meta) => {
                 if !meta.contains_key("kernelspec") {
-                    meta.insert("kernelspec".to_string(), json!(kernelspec_info.kernelspec));
+                    meta.shift_insert(
+                        0,
+                        "kernelspec".to_string(),
+                        json!(kernelspec_info.kernelspec),
+                    );
                 }
             }
             _ => bail!("Unexpected metadata type"),

--- a/src/smudge.rs
+++ b/src/smudge.rs
@@ -130,6 +130,28 @@ mod test {
             kernelspec_info.python_version.unwrap()
         );
     }
+    #[test]
+    fn test_add_to_blank_only_version() {
+        let kernelspec_info = KernelSpecInfo {
+            kernelspec: Value::Null,
+            python_version: Some("3.12.4".to_string()),
+        };
+        let nb_bytes = notebook_with_metadata_bytes(Value::Null);
+
+        let out_nb = maybe_replace_kernelspec(&nb_bytes, &kernelspec_info).unwrap();
+
+        assert_eq!(
+            out_nb
+                .metadata
+                .get("language_info")
+                .unwrap()
+                .get("version")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            kernelspec_info.python_version.unwrap()
+        );
+    }
 
     #[test]
     fn test_add_to_stripped() {

--- a/tests/e2e_notebooks/test_metadata_strip_kernelinfo.ipynb.expected
+++ b/tests/e2e_notebooks/test_metadata_strip_kernelinfo.ipynb.expected
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tests that cells with either `\"keep_output\": true` or `\"init_cell\": true` are not stripped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "init_cell": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1+1 # This cell has `\"init_cell:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "2+2 # This cell has `\"keep_output:\" true`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "3+3"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/e2e_notebooks/test_metadata_strip_kernelinfo.toml
+++ b/tests/e2e_notebooks/test_metadata_strip_kernelinfo.toml
@@ -1,0 +1,1 @@
+strip-kernel-info = true

--- a/tests/notebook_test.rs
+++ b/tests/notebook_test.rs
@@ -16,6 +16,7 @@ fn test_expected(path: &str, expected: &str, extra_args: &[&str], snapshot_name:
         .expect("command failed");
 
     let expected_content = fs::read_to_string(expected).expect("could not read expected");
+
     assert_eq!(output.stdout.to_str().unwrap(), expected_content);
     // check no errors after cleaning
     let mut check_output_cmd = Command::new(&cur_exe)
@@ -196,6 +197,28 @@ fn test_metadata_extra_keys() {
     test_config_match(
         "tests/e2e_notebooks/test_metadata_extra_keys.toml",
         &["--extra-keys", "metadata.kernelspec,metadata.language_info"],
+    );
+}
+
+#[test]
+fn test_strip_kernel_info() {
+    test_expected(
+        "tests/e2e_notebooks/test_metadata.ipynb",
+        "tests/e2e_notebooks/test_metadata_strip_kernelinfo.ipynb.expected",
+        &[
+            "--extra-keys",
+            "metadata.kernelspec,metadata.language_info.version",
+        ],
+        "test_metadata_strip_kernelinfo_cli",
+    );
+    test_expected(
+        "tests/e2e_notebooks/test_metadata.ipynb",
+        "tests/e2e_notebooks/test_metadata_strip_kernelinfo.ipynb.expected",
+        &[
+            "-c",
+            "tests/e2e_notebooks/test_metadata_strip_kernelinfo.toml",
+        ],
+        "test_metadata_strip_kernelinfo_cfg",
     );
 }
 

--- a/tests/record_and_smudge.rs
+++ b/tests/record_and_smudge.rs
@@ -1,0 +1,179 @@
+use std::{
+    fs::{self, File},
+    io::{Read, Write},
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+use nbwipers::{
+    record::{get_kernelspec_file, read_kernelspec_file, KernelSpecInfo},
+    schema::RawNotebook,
+    strip::write_nb,
+};
+use serde_json::json;
+
+#[test]
+fn test_blank_not_recorded() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+    let nb = RawNotebook::new();
+    let nb_path = temp_dir.path().join("notebook.ipynb");
+    write_nb(File::create(nb_path).unwrap(), &nb).unwrap();
+
+    Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["record"])
+        .output()
+        .expect("record failed");
+    let kernelspec_info = read_kernelspec_file(get_kernelspec_file(&temp_dir).unwrap())
+        .unwrap()
+        .unwrap();
+    assert!(kernelspec_info.is_empty())
+}
+
+#[test]
+fn test_metadata_recorded() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+    let python_version = "3.12.4".to_string();
+    let kernelspec = json!({
+        "name": "python3",
+        "display_name": "Python 3"
+    });
+    let dirty_nb = RawNotebook {
+        metadata: json!({
+            "kernelspec": kernelspec,
+            "language_info": {
+                "name": "python",
+                 "version": python_version
+            }
+        }),
+        ..Default::default()
+    };
+    let nb_rel_path = String::from("notebook.ipynb");
+    let nb_path = temp_dir.path().join(&nb_rel_path);
+    // let mut nb_bytes = Vec::new();
+    // write_nb(&mut nb_bytes, &nb).unwrap();
+    write_nb(File::create(&nb_path).unwrap(), &dirty_nb).unwrap();
+
+    Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["record"])
+        .output()
+        .expect("record failed");
+    let kernelspec_info = read_kernelspec_file(get_kernelspec_file(&temp_dir).unwrap())
+        .unwrap()
+        .unwrap();
+    assert!(!kernelspec_info.is_empty());
+    assert_eq!(
+        kernelspec_info.get(&nb_rel_path),
+        Some(&KernelSpecInfo {
+            kernelspec,
+            python_version: Some(python_version)
+        })
+    );
+
+    let strip_out = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["clean", &nb_rel_path, "--strip-kernel-info"])
+        .output()
+        .expect("clean failed");
+    dbg!(strip_out.stderr);
+    assert!(strip_out.status.success());
+
+    let mut nb_bytes = vec![];
+    fs::File::open(&nb_path)
+        .unwrap()
+        .read_to_end(&mut nb_bytes)
+        .unwrap();
+    assert!(strip_out.status.success());
+    let mut check_smudge_output = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["smudge", &nb_rel_path])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("smudge failed");
+    {
+        let mut check_in = check_smudge_output.stdin.take().unwrap();
+        check_in.write_all(&nb_bytes).unwrap()
+    }
+    let smudge_out = check_smudge_output.wait_with_output().unwrap();
+
+    // dbg!(String::from_utf8(smudge_out.stderr).unwrap());
+    assert!(smudge_out.status.success());
+    let clean_nb = serde_json::from_slice::<RawNotebook>(&nb_bytes).unwrap();
+    assert_ne!(dirty_nb, clean_nb);
+    let smudged_nb = serde_json::from_slice::<RawNotebook>(&smudge_out.stdout).unwrap();
+
+    assert_eq!(dirty_nb, smudged_nb);
+}
+
+#[test]
+fn test_invalid_git_dirs() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let not_git_dir_out = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["record"])
+        .output()
+        .expect("record failed");
+    assert!(!not_git_dir_out.status.success());
+    let stderr = String::from_utf8(not_git_dir_out.stderr).unwrap();
+    assert!(stderr.contains("Error: No .git dir"));
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    fs::create_dir_all(temp_dir.path().join(".git")).unwrap();
+
+    let not_not_workdir = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["record"])
+        .output()
+        .expect("record failed");
+
+    assert!(!not_not_workdir.status.success());
+    let stderr = String::from_utf8(not_not_workdir.stderr).unwrap();
+    dbg!(&stderr);
+    assert!(stderr.contains("Error: Invalid git repo"));
+}
+
+#[test]
+fn test_smudge_nothing() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+    let verbatim_bytes = Vec::from(b"Hello world!");
+
+    let mut check_smudge_output = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["smudge", "bananas.ipynb"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("smudge failed");
+    {
+        let mut check_in = check_smudge_output.stdin.take().unwrap();
+        check_in.write_all(&verbatim_bytes).unwrap()
+    }
+    let smudge_out = check_smudge_output.wait_with_output().unwrap();
+    assert_eq!(smudge_out.stdout, verbatim_bytes);
+}

--- a/tests/snapshots/notebook_test__test_metadata_strip_kernelinfo_cfg_json.snap
+++ b/tests/snapshots/notebook_test__test_metadata_strip_kernelinfo_cfg_json.snap
@@ -1,0 +1,54 @@
+---
+source: tests/notebook_test.rs
+expression: output.stdout.to_str().unwrap()
+---
+[
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "StripMeta",
+    "extra_key": "metadata.kernelspec"
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "StripMeta",
+    "extra_key": "metadata.language_info.version"
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "ClearOutput",
+    "cell_number": 3
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "ClearCount",
+    "cell_number": 1
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "ClearCount",
+    "cell_number": 2
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "ClearCount",
+    "cell_number": 3
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "CellStripMeta",
+    "cell_number": 1,
+    "extra_key": "cell.metadata.collapsed"
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "CellStripMeta",
+    "cell_number": 2,
+    "extra_key": "cell.metadata.collapsed"
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "CellStripMeta",
+    "cell_number": 3,
+    "extra_key": "cell.metadata.collapsed"
+  }
+]

--- a/tests/snapshots/notebook_test__test_metadata_strip_kernelinfo_cfg_text.snap
+++ b/tests/snapshots/notebook_test__test_metadata_strip_kernelinfo_cfg_text.snap
@@ -1,0 +1,13 @@
+---
+source: tests/notebook_test.rs
+expression: output.stdout.to_str().unwrap()
+---
+tests/e2e_notebooks/test_metadata.ipynb:Found notebook metadata: metadata.kernelspec
+tests/e2e_notebooks/test_metadata.ipynb:Found notebook metadata: metadata.language_info.version
+tests/e2e_notebooks/test_metadata.ipynb:cell 3: Found cell with output
+tests/e2e_notebooks/test_metadata.ipynb:cell 1: Found cell with execution count
+tests/e2e_notebooks/test_metadata.ipynb:cell 2: Found cell with execution count
+tests/e2e_notebooks/test_metadata.ipynb:cell 3: Found cell with execution count
+tests/e2e_notebooks/test_metadata.ipynb:cell 1: Found cell metadata cell.metadata.collapsed
+tests/e2e_notebooks/test_metadata.ipynb:cell 2: Found cell metadata cell.metadata.collapsed
+tests/e2e_notebooks/test_metadata.ipynb:cell 3: Found cell metadata cell.metadata.collapsed

--- a/tests/snapshots/notebook_test__test_metadata_strip_kernelinfo_cli_json.snap
+++ b/tests/snapshots/notebook_test__test_metadata_strip_kernelinfo_cli_json.snap
@@ -1,0 +1,54 @@
+---
+source: tests/notebook_test.rs
+expression: output.stdout.to_str().unwrap()
+---
+[
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "StripMeta",
+    "extra_key": "metadata.kernelspec"
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "StripMeta",
+    "extra_key": "metadata.language_info.version"
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "ClearOutput",
+    "cell_number": 3
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "ClearCount",
+    "cell_number": 1
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "ClearCount",
+    "cell_number": 2
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "ClearCount",
+    "cell_number": 3
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "CellStripMeta",
+    "cell_number": 1,
+    "extra_key": "cell.metadata.collapsed"
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "CellStripMeta",
+    "cell_number": 2,
+    "extra_key": "cell.metadata.collapsed"
+  },
+  {
+    "path": "tests/e2e_notebooks/test_metadata.ipynb",
+    "type": "CellStripMeta",
+    "cell_number": 3,
+    "extra_key": "cell.metadata.collapsed"
+  }
+]

--- a/tests/snapshots/notebook_test__test_metadata_strip_kernelinfo_cli_text.snap
+++ b/tests/snapshots/notebook_test__test_metadata_strip_kernelinfo_cli_text.snap
@@ -1,0 +1,13 @@
+---
+source: tests/notebook_test.rs
+expression: output.stdout.to_str().unwrap()
+---
+tests/e2e_notebooks/test_metadata.ipynb:Found notebook metadata: metadata.kernelspec
+tests/e2e_notebooks/test_metadata.ipynb:Found notebook metadata: metadata.language_info.version
+tests/e2e_notebooks/test_metadata.ipynb:cell 3: Found cell with output
+tests/e2e_notebooks/test_metadata.ipynb:cell 1: Found cell with execution count
+tests/e2e_notebooks/test_metadata.ipynb:cell 2: Found cell with execution count
+tests/e2e_notebooks/test_metadata.ipynb:cell 3: Found cell with execution count
+tests/e2e_notebooks/test_metadata.ipynb:cell 1: Found cell metadata cell.metadata.collapsed
+tests/e2e_notebooks/test_metadata.ipynb:cell 2: Found cell metadata cell.metadata.collapsed
+tests/e2e_notebooks/test_metadata.ipynb:cell 3: Found cell metadata cell.metadata.collapsed


### PR DESCRIPTION
To make it easier to share and collaborate on notebooks I often finding myself cleaning metadata that concerns the python kernel.
These are found in `metadata.kernelspec` and `metadata.language_info.version`.
I have made this easier by adding a `--strip-kernel-info` command line option and and config file option.

The problem with doing this is that the information gets lost when you switch branches or do git restore on your notebooks, which can be annoying.
To counteract this, I add a new command called `nbwipers record` which will record any non-empty kernel info to a json file in a git directory.
I have also added a hidden command `nbwipers smudge`, which is to be used as a smudge filter, that retrieves the kernel info from the json file on check out, and if it is missing in the notebook, adds it back in.