### PR TITLE
Doc improvements + Bump to 0.7.0

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.default]
+# flag a test as slow after 60s; kill it after 2 periods (120s) so a hung
+# test fails fast instead of blocking CI indefinitely
+slow-timeout = { period = "60s", terminate-after = 2 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.expected text eol=lf
+*.ipynb text eol=lf
+*.toml text eol=lf

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: taiki-e/install-action@nextest
       - name: Run tests
-        run: cargo nextest run --all-features
+        run: cargo nextest run --all-features --no-fail-fast
   coverage:
     name: coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,6 +22,19 @@ jobs:
         uses: actions/checkout@v6
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features
+  test:
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - uses: taiki-e/install-action@nextest
+      - name: Run tests
+        run: cargo nextest run --all-features
   coverage:
     name: coverage
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning].
 ### Fixed
 
 - `uninstall` no longer errors if the `.gitattributes` file contains comment lines. Comments are now preserved
+- the `check-large-files` hook could report a confusing `Broken pipe` error instead of `Git check-attr failed` when git exited before reading its input, e.g. outside a git repository
 - `record --remove` previously had no effect. It now removes the recorded kernel metadata for the given notebook paths
 - Add missing project metadata to the PyPI package
 - Fix a macOS-only test failure caused by symlinked temporary directories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning].
 ### Changed
 
 - Move to Rust edition 2024. The minimum supported Rust version for building from source is now 1.88, declared via `rust-version` in `Cargo.toml`
+- Directory exclude patterns now behave like gitignore: excluding a directory also excludes its contents in every code path (including the git filter), a bare or trailing-slash name such as `scratch/` matches at any depth, and patterns with a leading or middle separator are anchored to the config file's directory
 - Expand and correct the CLI help text: `record` and its flags are now documented, `show-config` and the id/exclude options have clearer descriptions
 - Document the `show-config`, `record` and `hook` subcommands and the record/smudge kernel-info workflow in the README
 - Run tests on Windows and macOS in CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-05
+
+### Changed
+
+- Move to Rust edition 2024. The minimum supported Rust version for building from source is now 1.88, declared via `rust-version` in `Cargo.toml`
+- Expand and correct the CLI help text: `record` and its flags are now documented, `show-config` and the id/exclude options have clearer descriptions
+- Document the `show-config`, `record` and `hook` subcommands and the record/smudge kernel-info workflow in the README
+- Run tests on Windows and macOS in CI
+
+### Fixed
+
+- `uninstall` no longer errors if the `.gitattributes` file contains comment lines. Comments are now preserved
+- `record --remove` previously had no effect. It now removes the recorded kernel metadata for the given notebook paths
+- Add missing project metadata to the PyPI package
+- Fix a macOS-only test failure caused by symlinked temporary directories
+
 ## [0.6.2] - 2026-05-12
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,15 +72,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -90,9 +90,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -114,20 +120,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -137,9 +143,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -153,9 +159,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -229,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -293,7 +299,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -359,12 +365,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -423,9 +459,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -472,12 +508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,22 +552,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "gix-actor"
-version = "0.41.0"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8"
+checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
 dependencies = [
  "bstr",
  "gix-date",
@@ -546,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.33.0"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
+checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -581,11 +609,11 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
+checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-path",
  "libc",
@@ -594,15 +622,14 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.3"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
+checksum = "3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0"
 dependencies = [
  "bstr",
  "gix-error",
  "itoa",
  "jiff",
- "smallvec",
 ]
 
 [[package]]
@@ -622,18 +649,18 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
+checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
 dependencies = [
  "gix-path",
  "gix-trace",
@@ -645,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
 dependencies = [
  "bstr",
  "fastrand",
@@ -659,11 +686,11 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
+checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -671,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -683,20 +710,20 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
+checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
 dependencies = [
  "gix-hash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-lock"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -724,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
+checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -736,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
 dependencies = [
  "bstr",
  "gix-error",
@@ -767,11 +794,11 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
+checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "gix-path",
  "libc",
  "windows-sys",
@@ -779,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "23.0.0"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
+checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
 dependencies = [
  "gix-fs",
  "libc",
@@ -791,15 +818,15 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 
 [[package]]
 name = "gix-utils"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
 dependencies = [
  "fastrand",
  "unicode-normalization",
@@ -807,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
 dependencies = [
  "bstr",
 ]
@@ -841,21 +868,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -910,12 +922,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,9 +929,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -967,7 +973,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -977,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -1011,24 +1017,25 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
+ "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1037,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -1052,13 +1059,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1076,12 +1082,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1112,30 +1112,30 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1271,16 +1271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1339,7 +1329,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1375,15 +1365,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1400,7 +1390,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1490,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -1513,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -1533,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1566,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1615,9 +1605,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1660,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1713,12 +1703,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1728,15 +1717,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1798,9 +1787,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-bom"
@@ -1825,21 +1814,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -1870,28 +1853,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1902,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1912,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1925,45 +1890,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -2067,103 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "nbwipers"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "nbwipers"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2024"
+rust-version = "1.88"
 description = "Wipe clean your Jupyter Notebooks!"
 readme = "README.md"
 homepage = "https://github.com/felixgwilliams/nbwipers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nbwipers"
 version = "0.6.2"
-edition = "2021"
+edition = "2024"
 description = "Wipe clean your Jupyter Notebooks!"
 readme = "README.md"
 homepage = "https://github.com/felixgwilliams/nbwipers"
@@ -46,4 +46,4 @@ tempfile = "3.10.0"
 markdown-help = ["dep:clap-markdown"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin_include)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin_include)", "cfg(coverage)"] }

--- a/CommandLineHelp.md
+++ b/CommandLineHelp.md
@@ -25,11 +25,11 @@ Wipe clean your Jupyter Notebooks!
 ### **Subcommands:**
 
 * `install` — Register nbwipers as a git filter for `ipynb` files
-* `clean-all` — clean all notebooks in a given path
-* `check` — check notebooks in a given path for elements that would be removed by `clean`
-* `clean` — clean a single notebook
-* `uninstall` — uninstall nbwipers as a git filter
-* `check-install` — check whether nbwipers is setup as a git filter
+* `clean-all` — Clean all notebooks in a given path
+* `check` — Check notebooks in a given path for elements that would be removed by `clean`
+* `clean` — Clean a single notebook
+* `uninstall` — Uninstall nbwipers as a git filter
+* `check-install` — Check whether nbwipers is setup as a git filter
 * `show-config` — Show configuration
 * `record` — Record Kernelspec metadata for notebooks
 * `hook` — Commands for pre-commit hooks
@@ -59,7 +59,7 @@ Register nbwipers as a git filter for `ipynb` files
 
 ## `nbwipers clean-all`
 
-clean all notebooks in a given path
+Clean all notebooks in a given path
 
 **Usage:** `nbwipers clean-all [OPTIONS] [FILES]...`
 
@@ -77,7 +77,7 @@ clean all notebooks in a given path
 * `--extra-keys <EXTRA_KEYS>` — extra keys to remove in the notebook or cell metadata, separated by commas. Must start with `metadata` or `cell.metadata`
 * `--drop-empty-cells` — drop empty cells. Disable with `--keep-empty-cells`
 * `--keep-output` — keep cell output. Disable with `--drop-output`
-* `--keep-count` — keep cell execution count. Disable with `--drop count`
+* `--keep-count` — keep cell execution count. Disable with `--drop-count`
 * `--drop-id` — remove cell ids and downgrade to nbformat 4.4. Conflicts with `--keep-id` and `--sequential-id`. Equivalent to `--id-action=drop`
 * `--keep-id` — keep cell ids (default). Conflicts with `--sequential-id` and `--drop-id`. Equivalent to `--id-action=keep`
 * `--sequential-id` — replace cell ids with sequential ids. Conflicts with `--keep-id` and `--drop-id`. Equivalent to `--id-action=sequential`
@@ -85,13 +85,13 @@ clean all notebooks in a given path
 * `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
 * `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
 * `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
-* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
-* `--exclude <EXCLUDE>` — List of file patterns to ignore
-* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore
+* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, even if they would otherwise be removed by `--extra-keys` or the default set of stripped keys
+* `--exclude <EXCLUDE>` — List of file patterns to ignore. Replaces any `exclude` patterns set in the configuration file
+* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore, on top of `exclude` and any `extend-exclude` patterns set in the configuration file
 
 ## `nbwipers check`
 
-check notebooks in a given path for elements that would be removed by `clean`
+Check notebooks in a given path for elements that would be removed by `clean`
 
 **Usage:** `nbwipers check [OPTIONS] [FILES]...`
 
@@ -103,7 +103,11 @@ check notebooks in a given path for elements that would be removed by `clean`
 
 * `-o`, `--output-format <OUTPUT_FORMAT>` — desired output format for diagnostics
 
-  Possible values: `text`, `json`
+  Possible values:
+  * `text`:
+    human-readable plain text diagnostics
+  * `json`:
+    machine-readable JSON diagnostics
 * `--stdin-file-name <STDIN_FILE_NAME>` — Name of file if stdin is used
 * `-c`, `--config <CONFIG>` — path to pyproject.toml/.nbwipers.toml/nbwipers.toml file containing nbwipers settings. If not given use the file in the current working directory or the first such file in its containing folders
 * `--isolated` — Ignore all configuration files
@@ -111,7 +115,7 @@ check notebooks in a given path for elements that would be removed by `clean`
 * `--extra-keys <EXTRA_KEYS>` — extra keys to remove in the notebook or cell metadata, separated by commas. Must start with `metadata` or `cell.metadata`
 * `--drop-empty-cells` — drop empty cells. Disable with `--keep-empty-cells`
 * `--keep-output` — keep cell output. Disable with `--drop-output`
-* `--keep-count` — keep cell execution count. Disable with `--drop count`
+* `--keep-count` — keep cell execution count. Disable with `--drop-count`
 * `--drop-id` — remove cell ids and downgrade to nbformat 4.4. Conflicts with `--keep-id` and `--sequential-id`. Equivalent to `--id-action=drop`
 * `--keep-id` — keep cell ids (default). Conflicts with `--sequential-id` and `--drop-id`. Equivalent to `--id-action=keep`
 * `--sequential-id` — replace cell ids with sequential ids. Conflicts with `--keep-id` and `--drop-id`. Equivalent to `--id-action=sequential`
@@ -119,13 +123,13 @@ check notebooks in a given path for elements that would be removed by `clean`
 * `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
 * `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
 * `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
-* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
-* `--exclude <EXCLUDE>` — List of file patterns to ignore
-* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore
+* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, even if they would otherwise be removed by `--extra-keys` or the default set of stripped keys
+* `--exclude <EXCLUDE>` — List of file patterns to ignore. Replaces any `exclude` patterns set in the configuration file
+* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore, on top of `exclude` and any `extend-exclude` patterns set in the configuration file
 
 ## `nbwipers clean`
 
-clean a single notebook
+Clean a single notebook
 
 **Usage:** `nbwipers clean [OPTIONS] <FILE>`
 
@@ -144,7 +148,7 @@ clean a single notebook
 * `--extra-keys <EXTRA_KEYS>` — extra keys to remove in the notebook or cell metadata, separated by commas. Must start with `metadata` or `cell.metadata`
 * `--drop-empty-cells` — drop empty cells. Disable with `--keep-empty-cells`
 * `--keep-output` — keep cell output. Disable with `--drop-output`
-* `--keep-count` — keep cell execution count. Disable with `--drop count`
+* `--keep-count` — keep cell execution count. Disable with `--drop-count`
 * `--drop-id` — remove cell ids and downgrade to nbformat 4.4. Conflicts with `--keep-id` and `--sequential-id`. Equivalent to `--id-action=drop`
 * `--keep-id` — keep cell ids (default). Conflicts with `--sequential-id` and `--drop-id`. Equivalent to `--id-action=keep`
 * `--sequential-id` — replace cell ids with sequential ids. Conflicts with `--keep-id` and `--drop-id`. Equivalent to `--id-action=sequential`
@@ -152,13 +156,13 @@ clean a single notebook
 * `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
 * `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
 * `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
-* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
-* `--exclude <EXCLUDE>` — List of file patterns to ignore
-* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore
+* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, even if they would otherwise be removed by `--extra-keys` or the default set of stripped keys
+* `--exclude <EXCLUDE>` — List of file patterns to ignore. Replaces any `exclude` patterns set in the configuration file
+* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore, on top of `exclude` and any `extend-exclude` patterns set in the configuration file
 
 ## `nbwipers uninstall`
 
-uninstall nbwipers as a git filter
+Uninstall nbwipers as a git filter
 
 **Usage:** `nbwipers uninstall [OPTIONS] <CONFIG_TYPE>`
 
@@ -181,7 +185,7 @@ uninstall nbwipers as a git filter
 
 ## `nbwipers check-install`
 
-check whether nbwipers is setup as a git filter
+Check whether nbwipers is setup as a git filter
 
 **Usage:** `nbwipers check-install [OPTIONS] [CONFIG_TYPE]`
 
@@ -209,14 +213,14 @@ Show configuration
 
 ### **Options:**
 
-* `--show-all` — Show all config including defaults Disable with `--no-show-defaults`
+* `--show-all` — Show all config including defaults. Disable with `--no-show-defaults`
 * `-c`, `--config <CONFIG>` — path to pyproject.toml/.nbwipers.toml/nbwipers.toml file containing nbwipers settings. If not given use the file in the current working directory or the first such file in its containing folders
 * `--isolated` — Ignore all configuration files
 * `--allow-no-notebooks` — Do not return an error if no notebooks are found
 * `--extra-keys <EXTRA_KEYS>` — extra keys to remove in the notebook or cell metadata, separated by commas. Must start with `metadata` or `cell.metadata`
 * `--drop-empty-cells` — drop empty cells. Disable with `--keep-empty-cells`
 * `--keep-output` — keep cell output. Disable with `--drop-output`
-* `--keep-count` — keep cell execution count. Disable with `--drop count`
+* `--keep-count` — keep cell execution count. Disable with `--drop-count`
 * `--drop-id` — remove cell ids and downgrade to nbformat 4.4. Conflicts with `--keep-id` and `--sequential-id`. Equivalent to `--id-action=drop`
 * `--keep-id` — keep cell ids (default). Conflicts with `--sequential-id` and `--drop-id`. Equivalent to `--id-action=keep`
 * `--sequential-id` — replace cell ids with sequential ids. Conflicts with `--keep-id` and `--drop-id`. Equivalent to `--id-action=sequential`
@@ -224,9 +228,9 @@ Show configuration
 * `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
 * `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
 * `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
-* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
-* `--exclude <EXCLUDE>` — List of file patterns to ignore
-* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore
+* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, even if they would otherwise be removed by `--extra-keys` or the default set of stripped keys
+* `--exclude <EXCLUDE>` — List of file patterns to ignore. Replaces any `exclude` patterns set in the configuration file
+* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore, on top of `exclude` and any `extend-exclude` patterns set in the configuration file
 
 ## `nbwipers record`
 
@@ -236,20 +240,20 @@ Record Kernelspec metadata for notebooks
 
 ### **Arguments:**
 
-* `<PATH>`
+* `<PATH>` — path to search for notebooks whose kernel metadata should be recorded. Defaults to the current directory
 
 #### **Options:**
 
-* `--remove <REMOVE>`
-* `--clear`
-* `--sync`
+* `--remove <REMOVE>` — remove recorded kernel metadata for these notebook paths, leaving other recorded entries untouched
+* `--clear` — remove all recorded kernel metadata without recording anything new
+* `--sync` — discard all recorded kernel metadata and rebuild it from the notebooks currently found under `path`, dropping entries for notebooks that are no longer found
 * `-c`, `--config <CONFIG>` — path to pyproject.toml/.nbwipers.toml/nbwipers.toml file containing nbwipers settings. If not given use the file in the current working directory or the first such file in its containing folders
 * `--isolated` — Ignore all configuration files
 * `--allow-no-notebooks` — Do not return an error if no notebooks are found
 * `--extra-keys <EXTRA_KEYS>` — extra keys to remove in the notebook or cell metadata, separated by commas. Must start with `metadata` or `cell.metadata`
 * `--drop-empty-cells` — drop empty cells. Disable with `--keep-empty-cells`
 * `--keep-output` — keep cell output. Disable with `--drop-output`
-* `--keep-count` — keep cell execution count. Disable with `--drop count`
+* `--keep-count` — keep cell execution count. Disable with `--drop-count`
 * `--drop-id` — remove cell ids and downgrade to nbformat 4.4. Conflicts with `--keep-id` and `--sequential-id`. Equivalent to `--id-action=drop`
 * `--keep-id` — keep cell ids (default). Conflicts with `--sequential-id` and `--drop-id`. Equivalent to `--id-action=keep`
 * `--sequential-id` — replace cell ids with sequential ids. Conflicts with `--keep-id` and `--drop-id`. Equivalent to `--id-action=sequential`
@@ -257,9 +261,9 @@ Record Kernelspec metadata for notebooks
 * `--strip-init-cell` — Strip init cell. Disable with `--keep-init-cell`
 * `--strip-kernel-info` — Strip kernel info. Namely, metadata.kernelspec and metadata.language_info.python_version. Disable with `--keep-kernel-info`
 * `--drop-tagged-cells <DROP_TAGGED_CELLS>` — comma-separated list of tags that will cause the cell to be dropped
-* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, regardless of if they appear in
-* `--exclude <EXCLUDE>` — List of file patterns to ignore
-* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore
+* `--keep-keys <KEEP_KEYS>` — List of metadata keys that should be kept, even if they would otherwise be removed by `--extra-keys` or the default set of stripped keys
+* `--exclude <EXCLUDE>` — List of file patterns to ignore. Replaces any `exclude` patterns set in the configuration file
+* `--extend-exclude <EXTEND_EXCLUDE>` — List of additional file patterns to ignore, on top of `exclude` and any `extend-exclude` patterns set in the configuration file
 
 ## `nbwipers hook`
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ nbwipers has a few subcommands that provide functionality related to cleaning Ju
 - `install` register nbwipers as a git filter for `ipynb` files. Equivalent to `nbstripout --install`
 - `uninstall` remove nbwipers as a git filter.
 - `check-install` check that `nbwipers` or `nbstripout` is installed in the local repo. This is used in the pre-commit hook.
+- `show-config` show the effective configuration nbwipers would use, merging the config file with any CLI overrides.
+- `record` record kernel metadata for notebooks in a local, git-untracked store, so it can be restored later even though `strip-kernel-info` removes it from committed notebooks. See [Preserving kernel info locally](#preserving-kernel-info-locally) below.
+- `hook` subcommands used by pre-commit-style hooks &mdash; currently `check-large-files`, which checks notebook file sizes after cleaning.
 
 The full options can be found in [`CommandLineHelp.md`](CommandLineHelp.md).
 
@@ -44,6 +47,32 @@ To check the notebooks in your folder, you can run the following
 ```shell
 nbwipers check .
 ```
+
+To see the configuration nbwipers would use in the current directory, you can run
+
+```shell
+nbwipers show-config
+```
+
+Add `--show-all` to also see the default values for settings that have not been explicitly configured.
+
+### Preserving kernel info locally
+
+`nbwipers install` sets up both a clean filter, which strips notebooks before they are committed, and a smudge filter, which runs when notebooks are checked out.
+
+If you enable `strip-kernel-info` (see [Configuration](#configuration)) so that kernelspec and python-version metadata never gets committed, you can still keep that information around locally with `record`:
+
+```shell
+nbwipers record .
+```
+
+This saves the kernel metadata for notebooks under the given path to `.git/x-nbwipers/kernelspec_store.json` &mdash; local to your clone and never committed. The next time you check out one of those notebooks, the smudge filter automatically restores its recorded kernel metadata, so each collaborator keeps their own kernel/python version info without it living in version control.
+
+To keep the local store tidy as notebooks come and go:
+
+- `nbwipers record --sync .` discards the whole store and rebuilds it from the notebooks currently found under `.`, dropping entries for notebooks that no longer exist.
+- `nbwipers record --remove path/to/notebook.ipynb` removes a specific notebook's entry, leaving the rest of the store untouched.
+- `nbwipers record --clear` wipes the store entirely.
 
 ### pre-commit
 

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ test-cov:
 
 # Regenerate the documentation file for the CLI
 cli-docs:
-    cargo run -q --features=markdown-help -- --markdown-help check | sed -z -e 's/\n\n *Possible values: `true`, `false`\n//g'  > CommandLineHelp.md
+    cargo run -q --features=markdown-help -- --markdown-help check | perl -0777 -pe 's/\n\n *Possible values: `true`, `false`\n//g'  > CommandLineHelp.md
     -rumdl check CommandLineHelp.md --fix
 
 # run the tests fr fr on god (run tests but allow dbg! and println! to display output)

--- a/src/cell_impl.rs
+++ b/src/cell_impl.rs
@@ -6,8 +6,8 @@ use crate::schema::{Cell, CodeCell, SourceValue};
 impl SourceValue {
     fn is_empty(&self) -> bool {
         match self {
-            Self::String(ref s) => s.trim().is_empty(),
-            Self::StringArray(ref s_vec) => s_vec.iter().all(|s| s.trim().is_empty()),
+            Self::String(s) => s.trim().is_empty(),
+            Self::StringArray(s_vec) => s_vec.iter().all(|s| s.trim().is_empty()),
         }
     }
 }
@@ -86,31 +86,31 @@ impl Cell {
 
     pub const fn get_source(&self) -> &SourceValue {
         match self {
-            Self::Code(ref c) => &c.source,
-            Self::Markdown(ref c) => &c.source,
-            Self::Raw(ref c) => &c.source,
+            Self::Code(c) => &c.source,
+            Self::Markdown(c) => &c.source,
+            Self::Raw(c) => &c.source,
         }
     }
 
     pub const fn get_metadata(&self) -> &Value {
         match self {
-            Self::Code(ref c) => &c.metadata,
-            Self::Markdown(ref c) => &c.metadata,
-            Self::Raw(ref c) => &c.metadata,
+            Self::Code(c) => &c.metadata,
+            Self::Markdown(c) => &c.metadata,
+            Self::Raw(c) => &c.metadata,
         }
     }
     pub fn get_metadata_mut(&mut self) -> &mut Value {
         match self {
-            Self::Code(ref mut c) => &mut c.metadata,
-            Self::Markdown(ref mut c) => &mut c.metadata,
-            Self::Raw(ref mut c) => &mut c.metadata,
+            Self::Code(c) => &mut c.metadata,
+            Self::Markdown(c) => &mut c.metadata,
+            Self::Raw(c) => &mut c.metadata,
         }
     }
     pub const fn get_id(&self) -> &Option<String> {
         match self {
-            Self::Code(ref c) => &c.id,
-            Self::Markdown(ref c) => &c.id,
-            Self::Raw(ref c) => &c.id,
+            Self::Code(c) => &c.id,
+            Self::Markdown(c) => &c.id,
+            Self::Raw(c) => &c.id,
         }
     }
     pub fn set_id(&mut self, new_id: Option<String>) -> Option<String> {
@@ -120,9 +120,9 @@ impl Cell {
             Self::Raw(c) => c.id.clone(),
         };
         match self {
-            Self::Code(ref mut c) => c.id = new_id,
-            Self::Markdown(ref mut c) => c.id = new_id,
-            Self::Raw(ref mut c) => c.id = new_id,
+            Self::Code(c) => c.id = new_id,
+            Self::Markdown(c) => c.id = new_id,
+            Self::Raw(c) => c.id = new_id,
         };
         prev_id
     }

--- a/src/check.rs
+++ b/src/check.rs
@@ -3,8 +3,8 @@ use std::{fmt::Display, path::Path};
 use crate::{
     config::IdAction,
     extra_keys::partition_extra_keys,
-    files::{relativize_path, NBReadError},
-    schema::{RawNotebook, ID_OPTIONAL_MAX_VERSION},
+    files::{NBReadError, relativize_path},
+    schema::{ID_OPTIONAL_MAX_VERSION, RawNotebook},
     settings::Settings,
     utils::get_value_child,
 };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,7 +55,7 @@ pub struct CommonArgs {
     #[arg(long, overrides_with("keep_output"), hide = true)]
     pub drop_output: bool,
 
-    /// keep cell execution count. Disable with `--drop count`
+    /// keep cell execution count. Disable with `--drop-count`
     #[arg(long, overrides_with("drop_count"))]
     pub keep_count: bool,
 
@@ -115,13 +115,13 @@ pub struct CommonArgs {
     #[arg(long, value_delimiter = ',')]
     pub drop_tagged_cells: Option<Vec<String>>,
 
-    /// List of metadata keys that should be kept, regardless of if they appear in
+    /// List of metadata keys that should be kept, even if they would otherwise be removed by `--extra-keys` or the default set of stripped keys
     #[arg(long, value_delimiter = ',')]
     pub keep_keys: Option<Vec<ExtraKey>>,
-    /// List of file patterns to ignore
+    /// List of file patterns to ignore. Replaces any `exclude` patterns set in the configuration file
     #[arg(long, value_delimiter = ',')]
     pub exclude: Option<Vec<FilePattern>>,
-    /// List of additional file patterns to ignore
+    /// List of additional file patterns to ignore, on top of `exclude` and any `extend-exclude` patterns set in the configuration file
     #[arg(long, value_delimiter = ',')]
     pub extend_exclude: Option<Vec<FilePattern>>,
 }
@@ -130,15 +130,15 @@ pub struct CommonArgs {
 pub enum Commands {
     /// Register nbwipers as a git filter for `ipynb` files
     Install(InstallCommand),
-    /// clean all notebooks in a given path
+    /// Clean all notebooks in a given path
     CleanAll(CleanAllCommand),
-    /// check notebooks in a given path for elements that would be removed by `clean`
+    /// Check notebooks in a given path for elements that would be removed by `clean`
     Check(CheckCommand),
-    /// clean a single notebook
+    /// Clean a single notebook
     Clean(CleanCommand),
-    /// uninstall nbwipers as a git filter
+    /// Uninstall nbwipers as a git filter
     Uninstall(UninstallCommand),
-    /// check whether nbwipers is setup as a git filter
+    /// Check whether nbwipers is setup as a git filter
     CheckInstall(CheckInstallCommand),
     /// Show configuration
     ShowConfig(ShowConfigCommand),
@@ -179,7 +179,7 @@ pub struct CheckLargeFilesCommand {
 
 #[derive(Clone, Debug, Parser)]
 pub struct ShowConfigCommand {
-    /// Show all config including defaults Disable with `--no-show-defaults`
+    /// Show all config including defaults. Disable with `--no-show-defaults`
     #[arg(long, overrides_with("no_show_defaults"))]
     pub show_all: bool,
 
@@ -243,8 +243,10 @@ pub struct CleanAllCommand {
 
 #[derive(Clone, Debug, ValueEnum, Copy, Default)]
 pub enum OutputFormat {
+    /// human-readable plain text diagnostics
     #[default]
     Text,
+    /// machine-readable JSON diagnostics
     Json,
 }
 #[derive(Clone, Debug, Parser)]
@@ -278,13 +280,17 @@ pub struct UninstallCommand {
 
 #[derive(Clone, Debug, Parser)]
 pub struct RecordCommand {
+    /// path to search for notebooks whose kernel metadata should be recorded. Defaults to the current directory
     pub path: Option<PathBuf>,
 
+    /// remove recorded kernel metadata for these notebook paths, leaving other recorded entries untouched
     #[arg(long)]
     pub remove: Vec<PathBuf>,
 
+    /// remove all recorded kernel metadata without recording anything new
     #[arg(long)]
     pub clear: bool,
+    /// discard all recorded kernel metadata and rebuild it from the notebooks currently found under `path`, dropping entries for notebooks that are no longer found
     #[arg(long)]
     pub sync: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use clap::{
-    builder::{styling::AnsiColor, Styles},
     Parser, Subcommand, ValueEnum,
+    builder::{Styles, styling::AnsiColor},
 };
 
 use crate::{

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,11 +116,19 @@ pub struct FilePattern {
 
 impl FilePattern {
     pub fn add_to(self, builder: &mut GlobSetBuilder) -> anyhow::Result<()> {
-        builder.add(Glob::new(&self.absolute.to_string_lossy())?);
+        let absolute = self.absolute.to_string_lossy();
+        builder.add(Glob::new(&absolute)?);
+        // also match everything below the pattern, so that excluding a
+        // directory covers its contents even when the files are matched
+        // directly rather than skipped during traversal
+        builder.add(Glob::new(&format!("{absolute}/**"))?);
 
-        // Add basename path.
-        if !self.pattern.contains(std::path::MAIN_SEPARATOR) {
-            builder.add(Glob::new(&self.pattern)?);
+        // Add basename path. As in gitignore, a trailing separator does not
+        // anchor the pattern; only a leading or middle separator does
+        let trimmed = self.pattern.trim_end_matches(std::path::is_separator);
+        if !trimmed.contains(std::path::is_separator) {
+            builder.add(Glob::new(trimmed)?);
+            builder.add(Glob::new(&format!("**/{trimmed}/**"))?);
         }
 
         Ok(())
@@ -160,7 +168,6 @@ impl Serialize for FilePattern {
 }
 fn make_globset<I: IntoIterator<Item = FilePattern>>(patterns: I) -> anyhow::Result<GlobSet> {
     let mut builder = GlobSetBuilder::new();
-    #[allow(clippy::unwrap_used)]
     for pattern in patterns {
         pattern.add_to(&mut builder)?;
     }

--- a/src/extra_keys.rs
+++ b/src/extra_keys.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, str::FromStr};
 
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -21,7 +21,7 @@ impl Serialize for ExtraKey {
 impl ExtraKey {
     pub const fn get_parts(&self) -> &Vec<String> {
         match self {
-            Self::Metadata(ref c) | Self::CellMeta(ref c) => &c.parts,
+            Self::Metadata(c) | Self::CellMeta(c) => &c.parts,
         }
     }
 }
@@ -104,8 +104,8 @@ pub fn partition_extra_keys<'a, I: IntoIterator<Item = &'a ExtraKey>>(
     let mut cell_keys = vec![];
     for extra_key in extra_keys {
         match extra_key {
-            ExtraKey::CellMeta(ref _cell_key) => cell_keys.push(extra_key),
-            ExtraKey::Metadata(ref _meta_key) => meta_keys.push(extra_key),
+            ExtraKey::CellMeta(_cell_key) => cell_keys.push(extra_key),
+            ExtraKey::Metadata(_meta_key) => meta_keys.push(extra_key),
         };
     }
     (cell_keys, meta_keys)

--- a/src/files.rs
+++ b/src/files.rs
@@ -41,10 +41,11 @@ pub fn relativize_path<P: AsRef<Path>>(path: P) -> String {
 
     let cwd = get_cwd();
 
-    path.strip_prefix(cwd).map_or_else(
+    let path_str = path.strip_prefix(cwd).map_or_else(
         |_| format!("{}", path.display()),
         |path| format!("{}", path.display()),
-    )
+    );
+    path_str.replace(std::path::MAIN_SEPARATOR, "/")
 }
 
 pub fn normalize_path_to<P: AsRef<Path>, R: AsRef<Path>>(path: P, root_path: R) -> PathBuf {
@@ -199,7 +200,11 @@ mod tests {
         dbg!(relativize_path(&subdir));
         assert_eq!(rel_dir, relativize_path(&subdir));
         if let Some(parent) = cur_dir.parent() {
-            assert_eq!(parent.to_str().unwrap(), relativize_path(parent));
+            let expected = parent
+                .to_str()
+                .unwrap()
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            assert_eq!(expected, relativize_path(parent));
         }
     }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,11 +1,11 @@
 use std::{
     ffi::OsStr,
     fs::File,
-    io::{stdin, BufReader},
+    io::{BufReader, stdin},
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use globset::Candidate;
 use ignore::{WalkBuilder, WalkState};
 use itertools::Itertools;

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -161,7 +161,12 @@ fn filter_lfs(files: &mut FxHashSet<PathBuf>) -> Result<(), Error> {
         .spawn()?;
     {
         let mut stdin = check_attr.stdin.take().context("Could not open stdin")?;
-        stdin.write_all(&file_list)?;
+        // git may exit without reading stdin (e.g. outside a repository);
+        // ignore the broken pipe so the exit-status check reports the real error
+        match stdin.write_all(&file_list) {
+            Err(e) if e.kind() != std::io::ErrorKind::BrokenPipe => return Err(e.into()),
+            _ => {}
+        }
     }
     let check_output = check_attr.wait_with_output()?;
     if !check_output.status.success() {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -9,7 +9,7 @@ use crate::cli::{CheckLargeFilesCommand, ConfigOverrides, HookCommands};
 use crate::files::read_nb;
 use crate::settings::Settings;
 use crate::strip::{strip_nb, write_nb};
-use anyhow::{anyhow, bail, Context, Error};
+use anyhow::{Context, Error, anyhow, bail};
 use itertools::Itertools;
 
 use rayon::prelude::*;
@@ -17,7 +17,7 @@ use rustc_hash::FxHashSet;
 
 pub fn hooks(cmd: &HookCommands) -> Result<(), Error> {
     match cmd {
-        HookCommands::CheckLargeFiles(ref inner_cmd) => check_large_files(inner_cmd),
+        HookCommands::CheckLargeFiles(inner_cmd) => check_large_files(inner_cmd),
     }
 }
 const DEFAULT_MAX_SIZE_KB: u64 = 500; // 500 KB
@@ -177,10 +177,10 @@ fn filter_lfs(files: &mut FxHashSet<PathBuf>) -> Result<(), Error> {
         let fname = chunk.next();
         // 3rd element index 2, but we already consumed one...
         let info = chunk.nth(1);
-        if let (Some(fname), Some(info)) = (fname.map(PathBuf::from), info) {
-            if info == "lfs" {
-                files.remove(&fname);
-            }
+        if let (Some(fname), Some(info)) = (fname.map(PathBuf::from), info)
+            && info == "lfs"
+        {
+            files.remove(&fname);
         }
     }
 

--- a/src/install/attributes.rs
+++ b/src/install/attributes.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail, Error};
-use gix_attributes::{parse::Kind, AssignmentRef, StateRef};
+use anyhow::{Error, bail};
+use gix_attributes::{AssignmentRef, StateRef, parse::Kind};
 
 use std::{
     fmt::Write as _,
@@ -11,7 +11,7 @@ use std::{
 
 use std::{collections::BTreeMap, io::Write};
 
-use super::{get_git_repo_and_work_tree, InstallStatus};
+use super::{InstallStatus, get_git_repo_and_work_tree};
 use crate::cli::GitConfigType;
 use itertools::Itertools;
 
@@ -140,32 +140,31 @@ pub fn uninstall_attributes(
                 Some(Ok(res)) => res,
                 Some(res) => res?,
             };
-            if let Kind::Pattern(patt) = kind {
-                if patt.to_string() == "*.ipynb" {
-                    let to_delete = x
-                        .into_iter()
-                        .map(|x| {
-                            let x = x?;
-                            if let StateRef::Value(s) = x.state {
-                                Ok((x, s.as_bstr() == "nbwipers"))
-                            } else {
-                                Ok((x, false))
-                            }
-                        })
-                        .collect::<Result<Vec<(AssignmentRef, bool)>, gix_attributes::name::Error>>(
-                        )?;
-                    if to_delete.iter().any(|(_, y)| *y) {
-                        to_write = true;
-                        let assignments = to_delete
-                            .iter()
-                            .filter(|(_x, y)| !y)
-                            .map(|(x, _y)| x.to_string())
-                            .join(" ");
-                        if assignments.is_empty() {
-                            line = String::new();
+            if let Kind::Pattern(patt) = kind
+                && patt.to_string() == "*.ipynb"
+            {
+                let to_delete = x
+                    .into_iter()
+                    .map(|x| {
+                        let x = x?;
+                        if let StateRef::Value(s) = x.state {
+                            Ok((x, s.as_bstr() == "nbwipers"))
                         } else {
-                            line = format!("{patt} {assignments}");
+                            Ok((x, false))
                         }
+                    })
+                    .collect::<Result<Vec<(AssignmentRef, bool)>, gix_attributes::name::Error>>()?;
+                if to_delete.iter().any(|(_, y)| *y) {
+                    to_write = true;
+                    let assignments = to_delete
+                        .iter()
+                        .filter(|(_x, y)| !y)
+                        .map(|(x, _y)| x.to_string())
+                        .join(" ");
+                    if assignments.is_empty() {
+                        line = String::new();
+                    } else {
+                        line = format!("{patt} {assignments}");
                     }
                 }
             };
@@ -193,21 +192,21 @@ fn check_attribute_file(attr_file_path: &Path) -> Result<InstallStatus, Error> {
         for line in lines {
             let (kind, assignments, _) = line?;
 
-            if let Kind::Pattern(patt) = kind {
-                if patt.to_string() == "*.ipynb" {
-                    for assignment in assignments {
-                        let assignment = assignment?;
-                        if let StateRef::Value(s) = assignment.state {
-                            if s.as_bstr() == "nbwipers" {
-                                status.nbwipers.filter |= assignment.name.as_str() == "filter";
-                                status.nbwipers.diff |= assignment.name.as_str() == "diff";
-                            }
-                            if s.as_bstr() == "ipynb" {
-                                status.nbstripout.diff |= assignment.name.as_str() == "diff";
-                            }
-                            if s.as_bstr() == "nbstripout" {
-                                status.nbstripout.filter |= assignment.name.as_str() == "filter";
-                            }
+            if let Kind::Pattern(patt) = kind
+                && patt.to_string() == "*.ipynb"
+            {
+                for assignment in assignments {
+                    let assignment = assignment?;
+                    if let StateRef::Value(s) = assignment.state {
+                        if s.as_bstr() == "nbwipers" {
+                            status.nbwipers.filter |= assignment.name.as_str() == "filter";
+                            status.nbwipers.diff |= assignment.name.as_str() == "diff";
+                        }
+                        if s.as_bstr() == "ipynb" {
+                            status.nbstripout.diff |= assignment.name.as_str() == "diff";
+                        }
+                        if s.as_bstr() == "nbstripout" {
+                            status.nbstripout.filter |= assignment.name.as_str() == "filter";
                         }
                     }
                 }

--- a/src/install/attributes.rs
+++ b/src/install/attributes.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, bail};
+use anyhow::Error;
 use gix_attributes::{AssignmentRef, StateRef, parse::Kind};
 
 use std::{
@@ -134,9 +134,12 @@ pub fn uninstall_attributes(
             if line.trim().is_empty() {
                 continue;
             }
-            // let (kind, x, _) = gix_attributes::parse(line.as_bytes()).next().unwrap()?;
+            // the parser yields nothing for comment lines; preserve them verbatim
             let (kind, x, _) = match gix_attributes::parse(line.as_bytes()).next() {
-                None => bail!("No pattern found in line : {line}"),
+                None => {
+                    writeln!(out, "{line}")?;
+                    continue;
+                }
                 Some(Ok(res)) => res,
                 Some(res) => res?,
             };

--- a/src/install/gitconfig.rs
+++ b/src/install/gitconfig.rs
@@ -1,10 +1,10 @@
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 
 use std::{fs, io::BufWriter, path::Path, path::PathBuf};
 
-use gix_config::{parse::section::ValueName, Source};
+use gix_config::{Source, parse::section::ValueName};
 
-use super::{get_git_repo_and_work_tree, InstallStatus, InstallToolStatus};
+use super::{InstallStatus, InstallToolStatus, get_git_repo_and_work_tree};
 use bstr::BStr;
 
 use crate::cli::GitConfigType;

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -1,6 +1,6 @@
 mod attributes;
 mod gitconfig;
-use anyhow::{bail, Error};
+use anyhow::{Error, bail};
 
 use std::{
     env,

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -185,7 +185,13 @@ mod test {
         create_dir_all(&subdir).unwrap();
         with_dir(&subdir, || {
             let res = get_git_repo_and_work_tree();
-            assert_eq!(res.unwrap().1.unwrap(), temp_dir.path());
+            // canonicalize both sides: on macOS `TMPDIR` lives under `/var/...`,
+            // a symlink to `/private/var/...`, and `current_dir()` (used inside
+            // `get_git_repo_and_work_tree`) returns the resolved form.
+            assert_eq!(
+                res.unwrap().1.unwrap().canonicalize().unwrap(),
+                temp_dir.path().canonicalize().unwrap()
+            );
         });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,27 +14,27 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, bail, Error};
+use anyhow::{Error, anyhow, bail};
 use clap::Parser;
 use colored::Colorize;
-use nbwipers::config::{resolve, Configuration};
+use nbwipers::config::{Configuration, resolve};
 use nbwipers::files::{
-    find_notebooks_or_stdin, read_nb, read_nb_stdin, relativize_path, FoundNotebooks,
+    FoundNotebooks, find_notebooks_or_stdin, read_nb, read_nb_stdin, relativize_path,
 };
 use nbwipers::hooks::hooks;
 use nbwipers::install;
 use nbwipers::record::record;
 use nbwipers::settings::Settings;
-use nbwipers::strip::{strip_single, StripResult};
+use nbwipers::strip::{StripResult, strip_single};
 use nbwipers::{
     check::{self as check, PathCheckResult},
     files::check_exclusions,
 };
 use nbwipers::{
     cli::{
-        self as cli, resolve_bool_arg, CheckCommand, CheckInstallCommand, CleanAllCommand,
-        CleanCommand, Commands, CommonArgs, InstallCommand, OutputFormat, ShowConfigCommand,
-        SmudgeCommand, UninstallCommand,
+        self as cli, CheckCommand, CheckInstallCommand, CleanAllCommand, CleanCommand, Commands,
+        CommonArgs, InstallCommand, OutputFormat, ShowConfigCommand, SmudgeCommand,
+        UninstallCommand, resolve_bool_arg,
     },
     smudge::smudge,
 };
@@ -208,7 +208,7 @@ fn main() -> Result<(), Error> {
     let cli = cli::Cli::parse();
     #[cfg(feature = "markdown-help")]
     if cli.markdown_help {
-        #[cfg(not(tarpaulin_include))]
+        #[cfg(not(coverage))]
         clap_markdown::print_help_markdown::<cli::Cli>();
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use nbwipers::settings::Settings;
 use nbwipers::strip::{StripResult, strip_single};
 use nbwipers::{
     check::{self as check, PathCheckResult},
-    files::check_exclusions,
+    files::{check_exclusions, normalize_path},
 };
 use nbwipers::{
     cli::{
@@ -55,7 +55,7 @@ fn check_all(
         FoundNotebooks::Stdin => match read_nb_stdin() {
             Ok(nb) => vec![(
                 Path::new("-"),
-                match stdin_file_name.map(|sfn| check_exclusions(sfn, &settings)) {
+                match stdin_file_name.map(|sfn| check_exclusions(&normalize_path(sfn), &settings)) {
                     Some(true) => vec![],
                     _ => nbwipers::check::check_nb(&nb, &settings),
                 },

--- a/src/record.rs
+++ b/src/record.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     cli::RecordCommand,
-    files::{find_notebooks, get_cwd, normalize_path, read_nb, relativize_path, FoundNotebooks},
+    files::{FoundNotebooks, find_notebooks, get_cwd, normalize_path, read_nb, relativize_path},
     schema::RawNotebook,
     settings::Settings,
 };

--- a/src/record.rs
+++ b/src/record.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     cli::RecordCommand,
-    files::{find_notebooks, get_cwd, read_nb, relativize_path, FoundNotebooks},
+    files::{find_notebooks, get_cwd, normalize_path, read_nb, relativize_path, FoundNotebooks},
     schema::RawNotebook,
     settings::Settings,
 };
@@ -93,6 +93,9 @@ pub fn record(cmd: RecordCommand) -> Result<(), Error> {
         for (nb, kernel) in kernelspecs {
             kernelspec_records.insert(nb, kernel);
         }
+    }
+    for remove_path in &cmd.remove {
+        kernelspec_records.shift_remove(&relativize_path(normalize_path(remove_path)));
     }
     let out_file = File::create(kernelspec_file)?;
     let mut buf = BufWriter::new(out_file);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,5 @@
 use crate::cli::ConfigOverrides;
-use crate::config::{resolve, Configuration, IdAction};
+use crate::config::{Configuration, IdAction, resolve};
 use crate::extra_keys::ExtraKey;
 use globset::GlobSet;
 use rustc_hash::FxHashSet;

--- a/src/smudge.rs
+++ b/src/smudge.rs
@@ -1,11 +1,11 @@
-use std::io::{stdin, Read};
-use std::io::{stdout, Write};
+use std::io::{Read, stdin};
+use std::io::{Write, stdout};
 
 use anyhow::bail;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::files::get_cwd;
-use crate::record::{get_kernelspec_file, read_kernelspec_file, KernelSpecInfo};
+use crate::record::{KernelSpecInfo, get_kernelspec_file, read_kernelspec_file};
 use crate::schema::RawNotebook;
 use crate::strip::write_nb;
 
@@ -83,7 +83,7 @@ fn maybe_replace_kernelspec(
 
 #[cfg(test)]
 mod test {
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::maybe_replace_kernelspec;
     use crate::{record::KernelSpecInfo, schema::RawNotebook, strip::write_nb};

--- a/src/strip.rs
+++ b/src/strip.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use crate::{
     config::IdAction,
     extra_keys::partition_extra_keys,
-    files::{NBReadError, NBWriteError, check_exclusions, read_nb, read_nb_stdin},
+    files::{NBReadError, NBWriteError, check_exclusions, normalize_path, read_nb, read_nb_stdin},
     schema::{ID_OPTIONAL_MAX_VERSION, RawNotebook},
     settings::Settings,
     utils::{get_value_child, pop_cell_key, pop_meta_key},
@@ -105,7 +105,9 @@ pub fn strip_single(
         (None, _) => strip_nb(nb, settings),
         (Some(_), false) => strip_nb(nb, settings),
         (Some(stdin_name), true) => {
-            if check_exclusions(stdin_name, settings) {
+            // git passes filter paths relative to the repo root; absolutize so
+            // they can match the absolutized exclude globs
+            if check_exclusions(&normalize_path(stdin_name), settings) {
                 (nb, false)
             } else {
                 strip_nb(nb, settings)

--- a/src/strip.rs
+++ b/src/strip.rs
@@ -12,8 +12,8 @@ use thiserror::Error;
 use crate::{
     config::IdAction,
     extra_keys::partition_extra_keys,
-    files::{check_exclusions, read_nb, read_nb_stdin, NBReadError, NBWriteError},
-    schema::{RawNotebook, ID_OPTIONAL_MAX_VERSION},
+    files::{NBReadError, NBWriteError, check_exclusions, read_nb, read_nb_stdin},
+    schema::{ID_OPTIONAL_MAX_VERSION, RawNotebook},
     settings::Settings,
     utils::{get_value_child, pop_cell_key, pop_meta_key},
 };
@@ -118,7 +118,6 @@ pub fn strip_single(
             let stdout = std::io::stdout();
             match write_nb(stdout, &strip_nb) {
                 Ok(()) => Ok(StripSuccess::from_stripped(stripped)),
-                #[cfg(not(tarpaulin_include))]
                 Err(e) => Err(e.into()),
             }
         }
@@ -128,7 +127,6 @@ pub fn strip_single(
             let writer = BufWriter::new(f);
             match write_nb(writer, &strip_nb) {
                 Ok(()) => Ok(StripSuccess::Stripped),
-                #[cfg(not(tarpaulin_include))]
                 Err(e) => Err(e.into()),
             }
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -876,6 +876,7 @@ fn test_large_files_outside_git_repo() {
         .output()
         .expect("command failed");
     assert!(!output.status.success());
+    dbg!(output.stdout.to_str_lossy());
     dbg!(output.stderr.to_str_lossy());
     assert!(
         output

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -264,6 +264,88 @@ fn test_handle_multiple_assignments() {
 }
 
 #[test]
+fn test_uninstall_preserves_comments() {
+    // regression test: uninstall used to bail with "No pattern found in line"
+    // on comment lines, leaving the nbwipers entries in place
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let config_file = temp_dir.path().join("gitconfig");
+    let attr_file = temp_dir.path().join("attributes");
+
+    fs::write(
+        &config_file,
+        "[filter \"nbwipers\"]\n\tclean = nbwipers clean -\n\tsmudge = cat\n",
+    )
+    .unwrap();
+    fs::write(
+        &attr_file,
+        r"# strip notebook outputs
+*.ipynb filter=nbwipers
+*.ipynb diff=nbwipers
+[attr]myattr text
+*.py text
+",
+    )
+    .unwrap();
+
+    let output = Command::new(cur_exe)
+        .args([
+            "uninstall",
+            "local",
+            "-g",
+            config_file.to_str().unwrap(),
+            "-a",
+            attr_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("command failed");
+    dbg!(output.stderr.as_bstr());
+    assert!(output.status.success());
+
+    let attr_file_contents = fs::read_to_string(&attr_file).unwrap();
+    assert!(attr_file_contents.contains("# strip notebook outputs"));
+    assert!(attr_file_contents.contains("[attr]myattr text"));
+    assert!(attr_file_contents.contains("*.py text"));
+    assert!(!attr_file_contents.contains("nbwipers"));
+}
+
+#[test]
+fn test_uninstall_invalid_attribute_line() {
+    // git itself rejects negative patterns in .gitattributes, so uninstall
+    // should surface the parse error rather than silently rewriting the file
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let config_file = temp_dir.path().join("gitconfig");
+    let attr_file = temp_dir.path().join("attributes");
+
+    fs::write(&config_file, "[filter \"nbwipers\"]\n\tclean = x\n").unwrap();
+    let attr_contents = "!*.ipynb filter=nbwipers\n*.ipynb filter=nbwipers\n";
+    fs::write(&attr_file, attr_contents).unwrap();
+
+    let output = Command::new(cur_exe)
+        .args([
+            "uninstall",
+            "local",
+            "-g",
+            config_file.to_str().unwrap(),
+            "-a",
+            attr_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+    assert!(
+        output
+            .stderr
+            .to_str()
+            .unwrap()
+            .contains("has a negative pattern")
+    );
+    // the attribute file must be left untouched on error
+    assert_eq!(fs::read_to_string(&attr_file).unwrap(), attr_contents);
+}
+
+#[test]
 fn test_check_install() {
     let temp_dir = tempfile::tempdir().unwrap();
     let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
@@ -742,6 +824,111 @@ fn test_large_files_lfs_skip() {
 }
 
 #[test]
+fn test_large_files_non_ipynb() {
+    // non-notebook files are measured by their on-disk size directly
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+
+    fs::write(temp_dir.path().join("big.py"), "a".repeat(1000 * 1024)).unwrap();
+
+    let output = Command::new(&cur_exe)
+        .current_dir(temp_dir.path())
+        .args(["hook", "check-large-files", "--enforce-all", "big.py"])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+    assert!(output.stdout.to_str().unwrap().contains("exceeds"));
+
+    // a higher limit lets the same file pass
+    let output = Command::new(&cur_exe)
+        .current_dir(temp_dir.path())
+        .args([
+            "hook",
+            "check-large-files",
+            "--enforce-all",
+            "--maxkb",
+            "2000",
+            "big.py",
+        ])
+        .output()
+        .expect("command failed");
+    assert!(output.status.success());
+}
+
+#[test]
+fn test_large_files_outside_git_repo() {
+    // the hook shells out to `git check-attr`, which fails outside a repo
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+
+    fs::write(temp_dir.path().join("big.py"), "a".repeat(1000 * 1024)).unwrap();
+
+    let output = Command::new(&cur_exe)
+        .current_dir(temp_dir.path())
+        .args(["hook", "check-large-files", "--enforce-all", "big.py"])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+    assert!(
+        output
+            .stderr
+            .to_str()
+            .unwrap()
+            .contains("Git check-attr failed")
+    );
+}
+
+#[test]
+fn test_large_files_invalid_config() {
+    // if the nbwipers settings can't be constructed, the hook warns and
+    // falls back to the on-disk size instead of the stripped size
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+
+    let nb = RawNotebook::default();
+    {
+        let f = fs::File::create(temp_dir.path().join("nb.ipynb")).unwrap();
+        write_nb(BufWriter::new(f), &nb).unwrap();
+    }
+    fs::write(temp_dir.path().join("bad.toml"), "not = [valid toml").unwrap();
+
+    let output = Command::new(&cur_exe)
+        .current_dir(temp_dir.path())
+        .args([
+            "hook",
+            "check-large-files",
+            "--enforce-all",
+            "-c",
+            "bad.toml",
+            "nb.ipynb",
+        ])
+        .output()
+        .expect("command failed");
+    assert!(output.status.success());
+    assert!(
+        output
+            .stderr
+            .to_str()
+            .unwrap()
+            .contains("Could not parse nb file")
+    );
+}
+
+#[test]
 fn test_invalid_stdin() {
     let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
 
@@ -760,4 +947,70 @@ fn test_invalid_stdin() {
     }
     let check_output = check_output_cmd.wait_with_output().expect("Command failed");
     assert!(!check_output.status.success())
+}
+
+#[test]
+fn test_show_config_exclude_patterns() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+
+    fs::write(
+        temp_dir.path().join(".nbwipers.toml"),
+        "exclude = [\"vendored*.ipynb\"]\nextend-exclude = [\"scratch/\"]\n",
+    )
+    .unwrap();
+
+    let output = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["show-config"])
+        .output()
+        .expect("command failed");
+    assert!(output.status.success());
+    let stdout = output.stdout.to_str().unwrap();
+    assert!(stdout.contains("vendored*.ipynb"));
+    assert!(stdout.contains("scratch/"));
+}
+
+#[test]
+fn test_clean_file_not_found() {
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let output = Command::new(cur_exe)
+        .args(["clean", "no_such_notebook.ipynb"])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_clean_all_non_interactive_confirmation() {
+    // without --yes, clean-all asks for confirmation; when stdin is not a
+    // terminal the prompt fails, and no notebook may be modified
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+
+    let nb = RawNotebook {
+        cells: vec![Cell::Code(CodeCell {
+            source: SourceValue::StringArray(vec!["1 + 1".to_string()]),
+            metadata: Value::Null,
+            execution_count: Some(1),
+            outputs: vec![],
+            id: None,
+        })],
+        ..Default::default()
+    };
+    let nb_path = temp_dir.path().join("nb.ipynb");
+    {
+        let f = fs::File::create(&nb_path).unwrap();
+        write_nb(BufWriter::new(f), &nb).unwrap();
+    }
+    let before = fs::read_to_string(&nb_path).unwrap();
+
+    let output = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["clean-all", "."])
+        .stdin(Stdio::null())
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+    assert_eq!(fs::read_to_string(&nb_path).unwrap(), before);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5,7 +5,7 @@ use nbwipers::{
     schema::{Cell, CodeCell, RawNotebook, SourceValue},
     strip::write_nb,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 #[test]
 fn test_no_notebooks() {
@@ -21,11 +21,13 @@ fn test_no_notebooks() {
             .output()
             .expect("command failed");
         assert!(!output.status.success());
-        assert!(output
-            .stderr
-            .to_str()
-            .unwrap()
-            .contains("Error: Could not find any notebooks in path(s)"));
+        assert!(
+            output
+                .stderr
+                .to_str()
+                .unwrap()
+                .contains("Error: Could not find any notebooks in path(s)")
+        );
         let output = Command::new(&cur_exe)
             .current_dir(&temp_dir)
             .args(["check", ".", "--allow-no-notebooks"])
@@ -359,6 +361,83 @@ fn test_check_install() {
 }
 
 #[test]
+fn test_check_install_fresh_repo() {
+    // a git repo where nothing has ever been installed: the default
+    // `.gitattributes` and git config don't exist yet, so nbwipers should
+    // report cleanly that it isn't installed rather than erroring.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+
+    let output = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["check-install"])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+
+    let output = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["check-install", "local"])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_check_install_bare_repo() {
+    // a bare repo has no work tree, so there's nowhere for a default
+    // `.gitattributes` to live; nbwipers should treat that as "not installed"
+    // rather than erroring.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init", "--bare"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+
+    let output = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["check-install", "local"])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_uninstall_fresh_repo_defaults() {
+    // uninstall using the default (non-explicit) git config file and
+    // `.gitattributes` resolution, in a repo where nothing was ever
+    // installed. Both files need their parent directories/resolution paths
+    // handled even though neither file exists yet.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+
+    let output = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["uninstall", "local"])
+        .output()
+        .expect("command failed");
+    assert!(output.status.success());
+}
+
+#[test]
 fn test_invalid_format() {
     let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
 
@@ -426,6 +505,23 @@ fn test_strip_all_error() {
     dbg!(&stdout);
     assert!(!output.status.success());
     assert!(stdout.contains("Read error"));
+}
+
+#[test]
+fn test_clean_all_stdin_not_supported() {
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let output = Command::new(cur_exe)
+        .args(["clean-all", "-"])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+    assert!(
+        output
+            .stderr
+            .to_str()
+            .unwrap()
+            .contains("`strip-all` does not support stdin")
+    );
 }
 
 #[test]
@@ -576,10 +672,12 @@ fn test_large_files() {
     dbg!(output.stdout.as_bstr());
     dbg!(output.stderr.as_bstr());
     assert!(!output.status.success());
-    assert!(output
-        .stderr
-        .as_bstr()
-        .contains_str(b"Could not parse nb file"));
+    assert!(
+        output
+            .stderr
+            .as_bstr()
+            .contains_str(b"Could not parse nb file")
+    );
 
     let git_add_out = Command::new("git")
         .current_dir(&temp_dir)
@@ -598,6 +696,49 @@ fn test_large_files() {
         .expect("command failed");
 
     assert!(!output.status.success());
+}
+
+#[test]
+fn test_large_files_lfs_skip() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+
+    // a large, non-notebook-JSON file so its raw on-disk size is used directly
+    fs::write(
+        temp_dir.path().join("lfs_nb.ipynb"),
+        "a".repeat(1000 * 1024),
+    )
+    .unwrap();
+
+    // without any lfs attribute, the large file trips the check
+    let output = Command::new(&cur_exe)
+        .current_dir(temp_dir.path())
+        .args(["hook", "check-large-files", "--enforce-all", "lfs_nb.ipynb"])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+
+    // mark it as lfs-tracked; the hook measures on-disk size, not the (small)
+    // lfs pointer file git would actually store, so it should skip it entirely
+    fs::write(
+        temp_dir.path().join(".gitattributes"),
+        "lfs_nb.ipynb filter=lfs\n",
+    )
+    .unwrap();
+
+    let output = Command::new(&cur_exe)
+        .current_dir(temp_dir.path())
+        .args(["hook", "check-large-files", "--enforce-all", "lfs_nb.ipynb"])
+        .output()
+        .expect("command failed");
+    assert!(output.status.success());
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -876,6 +876,7 @@ fn test_large_files_outside_git_repo() {
         .output()
         .expect("command failed");
     assert!(!output.status.success());
+    dbg!(output.stderr.to_str_lossy());
     assert!(
         output
             .stderr

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -982,6 +982,9 @@ fn test_clean_file_not_found() {
 }
 
 #[test]
+// on Windows the confirmation prompt reads from the console device rather
+// than stdin, so it hangs waiting for input even with stdin closed
+#[cfg(not(windows))]
 fn test_clean_all_non_interactive_confirmation() {
     // without --yes, clean-all asks for confirmation; when stdin is not a
     // terminal the prompt fails, and no notebook may be modified

--- a/tests/notebook_test.rs
+++ b/tests/notebook_test.rs
@@ -361,7 +361,10 @@ fn test_metadata_period() {
     test_expected(
         "tests/e2e_notebooks/test_metadata_period.ipynb",
         "tests/e2e_notebooks/test_metadata_period.ipynb.expected",
-        &["--extra-keys", "cell.metadata.application/vnd.databricks.v1+cell,metadata.application/vnd.databricks.v1+notebook"],
+        &[
+            "--extra-keys",
+            "cell.metadata.application/vnd.databricks.v1+cell,metadata.application/vnd.databricks.v1+notebook",
+        ],
         "test_metadata_period_cli",
     );
     test_expected(
@@ -373,7 +376,10 @@ fn test_metadata_period() {
 
     test_config_match(
         "tests/e2e_notebooks/test_metadata_period.toml",
-        &["--extra-keys", "cell.metadata.application/vnd.databricks.v1+cell,metadata.application/vnd.databricks.v1+notebook"],
+        &[
+            "--extra-keys",
+            "cell.metadata.application/vnd.databricks.v1+cell,metadata.application/vnd.databricks.v1+notebook",
+        ],
     );
 }
 #[test]

--- a/tests/notebook_test.rs
+++ b/tests/notebook_test.rs
@@ -517,31 +517,117 @@ fn test_exclusions() {
     let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
     // the notebooks are full of issues
     let output = Command::new(&cur_exe)
-        .args(["check", "tests/e2e_notebooks", "-o", "text"])
+        .args(["check", "tests/e2e_notebooks", "-o", "text", "--isolated"])
         // .args([])
         .output()
         .expect("command failed");
     assert!(!output.status.success());
     // but if we exclude them, it should pass
     let output = Command::new(&cur_exe)
-        .args(["check", "tests/e2e_notebooks", "-o", "text"])
-        .args(["--exclude", "tests/e2e_notebooks", "--allow-no-notebooks"])
+        .args(["check", "tests/e2e_notebooks", "-o", "text", "--isolated"])
+        .args(["--exclude", "tests/e2e_notebooks/*", "--allow-no-notebooks"])
         .output()
         .expect("command failed");
-    dbg!(output.stderr.as_bstr());
     assert!(output.status.success());
     // and let's exclude them another way
     let output = Command::new(&cur_exe)
-        .args(["check", "tests/e2e_notebooks", "-o", "text"])
+        .args(["check", "tests/e2e_notebooks", "-o", "text", "--isolated"])
         .args([
             "--extend-exclude",
-            "tests/e2e_notebooks",
+            "tests/e2e_notebooks/*",
             "--allow-no-notebooks",
         ])
         .output()
         .expect("command failed");
     dbg!(output.stderr.as_bstr());
     assert!(output.status.success());
+}
+
+#[test]
+fn test_exclude_directory_patterns() {
+    // directory patterns behave like gitignore: a bare or trailing-slash name
+    // matches directories at any depth and covers their contents in every
+    // code path, while a pattern with a leading/middle separator is anchored
+    // to the config file's directory
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let dirty_nb = fs::read_to_string("tests/e2e_notebooks/test_nbformat45.ipynb").unwrap();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let nested = temp_dir.path().join("nested/scratch");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("inner.ipynb"), &dirty_nb).unwrap();
+
+    for pattern in ["scratch", "scratch/", "nested/scratch/"] {
+        fs::write(
+            temp_dir.path().join(".nbwipers.toml"),
+            format!("exclude = [\"{pattern}\"]\n"),
+        )
+        .unwrap();
+
+        // walking from the root skips the excluded directory
+        let output = Command::new(&cur_exe)
+            .current_dir(&temp_dir)
+            .args(["check", ".", "--allow-no-notebooks"])
+            .output()
+            .expect("command failed");
+        assert!(output.status.success(), "check . with exclude {pattern}");
+
+        // walking from inside the excluded directory matches the files directly
+        let output = Command::new(&cur_exe)
+            .current_dir(&temp_dir)
+            .args(["check", "nested/scratch", "--allow-no-notebooks"])
+            .output()
+            .expect("command failed");
+        assert!(
+            output.status.success(),
+            "check nested/scratch with exclude {pattern}"
+        );
+
+        // the git filter path passes a repo-relative file name; regression
+        // test: directory excludes previously never matched here
+        let mut clean_cmd = Command::new(&cur_exe)
+            .current_dir(&temp_dir)
+            .args([
+                "clean",
+                "-",
+                "--stdin-file-name",
+                "nested/scratch/inner.ipynb",
+                "--respect-exclusions",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("command failed");
+        {
+            let mut stdin = clean_cmd.stdin.take().unwrap();
+            stdin.write_all(dirty_nb.as_bytes()).unwrap();
+        }
+        let clean_out = clean_cmd.wait_with_output().unwrap();
+        assert!(clean_out.status.success());
+        assert!(
+            clean_out
+                .stdout
+                .to_str()
+                .unwrap()
+                .contains("\"execution_count\": 1"),
+            "git filter should pass excluded file through unchanged for {pattern}"
+        );
+    }
+
+    // an anchored pattern must not exclude a same-named directory elsewhere
+    fs::write(
+        temp_dir.path().join(".nbwipers.toml"),
+        "exclude = [\"other/scratch/\"]\n",
+    )
+    .unwrap();
+    let output = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["check", "."])
+        .output()
+        .expect("command failed");
+    assert!(!output.status.success());
+    assert!(output.stdout.to_str().unwrap().contains("inner.ipynb"));
 }
 
 #[test]
@@ -561,8 +647,8 @@ fn test_strip_stdin() {
             "--stdin-file-name",
             "tests/e2e_notebooks/test_nbformat45.ipynb",
             "--respect-exclusions",
+            "--isolated",
         ])
-        // .args(extra_args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -586,6 +672,7 @@ fn test_strip_stdin() {
             "--respect-exclusions",
             "--exclude",
             "test_nbformat45.ipynb",
+            "--isolated",
         ])
         // .args(extra_args)
         .stdin(Stdio::piped())
@@ -612,6 +699,7 @@ fn test_strip_stdin() {
             "test_nbformat45.ipynb",
             "--stdin-file-name",
             "tests/e2e_notebooks/test_nbformat45.ipynb",
+            "--isolated",
         ])
         // .args(extra_args)
         .stdin(Stdio::piped())
@@ -644,6 +732,7 @@ fn test_strip_stdin() {
             "--stdin-file-name",
             "tests/e2e_notebooks/test_nbformat45.ipynb",
             "--respect-exclusions",
+            "--isolated",
         ])
         // .args(extra_args)
         .stdin(Stdio::piped())

--- a/tests/record_and_smudge.rs
+++ b/tests/record_and_smudge.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use nbwipers::{
-    record::{get_kernelspec_file, read_kernelspec_file, KernelSpecInfo},
+    record::{KernelSpecInfo, get_kernelspec_file, read_kernelspec_file},
     schema::RawNotebook,
     strip::write_nb,
 };

--- a/tests/record_and_smudge.rs
+++ b/tests/record_and_smudge.rs
@@ -251,6 +251,70 @@ fn record_clear_sync() {
     assert!(!third_kernel_info.contains_key(nb2_rel));
 }
 #[test]
+fn record_remove() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+    let python_version = "3.12.4".to_string();
+    let kernelspec = json!({
+        "name": "python3",
+        "display_name": "Python 3"
+    });
+    let dirty_nb = RawNotebook {
+        metadata: json!({
+            "kernelspec": kernelspec,
+            "language_info": {
+                "name": "python",
+                 "version": python_version
+            }
+        }),
+        ..Default::default()
+    };
+    let nb1_rel = "nb1.ipynb";
+    let nb2_rel = "nb2.ipynb";
+
+    write_nb(
+        File::create(temp_dir.path().join(nb1_rel)).unwrap(),
+        &dirty_nb,
+    )
+    .unwrap();
+    write_nb(
+        File::create(temp_dir.path().join(nb2_rel)).unwrap(),
+        &dirty_nb,
+    )
+    .unwrap();
+    Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["record"])
+        .output()
+        .expect("record failed");
+    let first_kernel_info = read_kernelspec_file(get_kernelspec_file(temp_dir.path()).unwrap())
+        .unwrap()
+        .unwrap();
+    assert!(first_kernel_info.contains_key(nb1_rel));
+    assert!(first_kernel_info.contains_key(nb2_rel));
+
+    // both notebooks are still present on disk, so --remove is the only thing
+    // that should drop nb2's entry (unlike --sync, which only drops entries
+    // for files that are no longer found).
+    Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["record", "--remove", nb2_rel])
+        .output()
+        .expect("record failed");
+    let second_kernel_info = read_kernelspec_file(get_kernelspec_file(temp_dir.path()).unwrap())
+        .unwrap()
+        .unwrap();
+    assert!(second_kernel_info.contains_key(nb1_rel));
+    assert!(!second_kernel_info.contains_key(nb2_rel));
+}
+
+#[test]
 fn test_record_nothing() {
     let temp_dir = tempfile::tempdir().unwrap();
     let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));

--- a/tests/record_and_smudge.rs
+++ b/tests/record_and_smudge.rs
@@ -315,6 +315,47 @@ fn record_remove() {
 }
 
 #[test]
+fn record_skips_unparsable_notebooks() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));
+    let git_init_out = Command::new("git")
+        .current_dir(&temp_dir)
+        .args(["init"])
+        .output()
+        .expect("git init failed");
+    assert!(git_init_out.status.success());
+
+    let valid_nb = RawNotebook {
+        metadata: json!({
+            "kernelspec": {
+                "name": "python3",
+                "display_name": "Python 3"
+            }
+        }),
+        ..Default::default()
+    };
+    write_nb(
+        File::create(temp_dir.path().join("valid.ipynb")).unwrap(),
+        &valid_nb,
+    )
+    .unwrap();
+    fs::write(temp_dir.path().join("garbage.ipynb"), "not json at all").unwrap();
+
+    let out = Command::new(&cur_exe)
+        .current_dir(&temp_dir)
+        .args(["record"])
+        .output()
+        .expect("record failed");
+    assert!(out.status.success());
+
+    let kernelspec_info = read_kernelspec_file(get_kernelspec_file(temp_dir.path()).unwrap())
+        .unwrap()
+        .unwrap();
+    assert!(kernelspec_info.contains_key("valid.ipynb"));
+    assert!(!kernelspec_info.contains_key("garbage.ipynb"));
+}
+
+#[test]
 fn test_record_nothing() {
     let temp_dir = tempfile::tempdir().unwrap();
     let cur_exe = PathBuf::from(env!("CARGO_BIN_EXE_nbwipers"));


### PR DESCRIPTION

### Changed

- Move to Rust edition 2024. The minimum supported Rust version for building from source is now 1.88, declared via `rust-version` in `Cargo.toml`
- Expand and correct the CLI help text: `record` and its flags are now documented, `show-config` and the id/exclude options have clearer descriptions
- Document the `show-config`, `record` and `hook` subcommands and the record/smudge kernel-info workflow in the README
- Run tests on Windows and macOS in CI

### Fixed

- `uninstall` no longer errors if the `.gitattributes` file contains comment lines. Comments are now preserved
- `record --remove` previously had no effect. It now removes the recorded kernel metadata for the given notebook paths
- Add missing project metadata to the PyPI package
- Fix a macOS-only test failure caused by symlinked temporary directories